### PR TITLE
fix numpy deprecated methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.9]
+
+### Fixed
+
+- `numpy`-related errors when converting an `ndim > 0` array to a scalar
+- `xarray` warnings about `.argmax()` calls
+- Boundary case in `plot_nanofocus` when all focus estimates are identical and `.std()` is 0
+
 ## [0.4.8]
 
 ### Added

--- a/peaks/core/display/plotting.py
+++ b/peaks/core/display/plotting.py
@@ -955,7 +955,7 @@ def plot_nanofocus(data, focus="defocus"):
     # along the spatial dimension
     mean_abs_deriv_smoothed = mean_abs_deriv.smooth(**{focus: 2 * focus_step})
     mean_abs_deriv_smoothed.plot(ax=axes[1, 0], c="black", alpha=0.2)
-    max_mean_abs_deriv = mean_abs_deriv_smoothed.argmax()
+    max_mean_abs_deriv = mean_abs_deriv_smoothed.argmax(dim="defocus")
     focal_point_mean_abs_deriv = mean_abs_deriv[focus].data[max_mean_abs_deriv]
     axes[1, 0].set_title(
         "Mean of the abs(deriv) estimate: {focal_point}".format(
@@ -976,7 +976,7 @@ def plot_nanofocus(data, focus="defocus"):
     # along the spatial dimension
     max_abs_deriv_smoothed = max_abs_deriv.smooth(**{focus: 2 * focus_step})
     max_abs_deriv_smoothed.plot(ax=axes[1, 1], c="black", alpha=0.2)
-    max_max_abs_deriv = max_abs_deriv_smoothed.argmax()
+    max_max_abs_deriv = max_abs_deriv_smoothed.argmax(dim="defocus")
     focal_point_max_abs_deriv = max_abs_deriv[focus].data[max_max_abs_deriv]
     axes[1, 1].set_title(
         "Max of the abs(deriv) estimate: {focal_point}".format(
@@ -995,7 +995,7 @@ def plot_nanofocus(data, focus="defocus"):
     # Estimate and plot the focal point from the focus-dependent variance along the spatial dimension
     variance_smoothed = variance.smooth(**{focus: 2 * focus_step})
     variance_smoothed.plot(ax=axes[2, 0], c="black", alpha=0.2)
-    max_variance = variance_smoothed.argmax()
+    max_variance = variance_smoothed.argmax(dim="defocus")
     focal_point_max_variance = variance[focus].data[max_variance]
     axes[2, 0].set_title(
         "Max of the variance estimate: {focal_point}".format(
@@ -1016,7 +1016,7 @@ def plot_nanofocus(data, focus="defocus"):
     else:
         FFT_data.data = abs(fft(data.pint.dequantify().data))  # Perform FFT
     FFT_data = FFT_data.pint.quantify(data.pint.units)
-    FFT_data_out = FFT_data.isel({spatial: FFT_data.argmax(spatial).data[0] + 1})
+    FFT_data_out = FFT_data.isel({spatial: FFT_data.argmax(dim=spatial).data[0] + 1})
 
     # Plot the FFT analysis results
     FFT_data_out.plot(ax=axes[2, 1], c="black")
@@ -1024,7 +1024,7 @@ def plot_nanofocus(data, focus="defocus"):
     # Estimate and plot the focal point from the FFT analysis
     FFT_data_out_smoothed = FFT_data_out.smooth(**{focus: 2 * focus_step})
     FFT_data_out_smoothed.plot(ax=axes[2, 1], c="black", alpha=0.2)
-    max_FFT = FFT_data_out_smoothed.argmax()
+    max_FFT = FFT_data_out_smoothed.argmax(dim="defocus")
     focal_point_max_FFT = FFT_data_out[focus].data[max_FFT]
     axes[2, 1].set_title(
         "Fast Fourier transform estimate: {focal_point}".format(
@@ -1048,7 +1048,7 @@ def plot_nanofocus(data, focus="defocus"):
     )
     estimates_no_outliers = []
     for i, item in enumerate(abs(abs(estimates) - abs(estimates.mean()))):
-        if item < (2 * estimates.std()):
+        if item <= (2 * estimates.std()):
             estimates_no_outliers.append(estimates[i])
     avg_estimate = round(np.mean(estimates_no_outliers), 2)
 

--- a/peaks/core/fileIO/loaders/diamond.py
+++ b/peaks/core/fileIO/loaders/diamond.py
@@ -95,6 +95,10 @@ class DiamondNXSLoader(BaseHDF5DataLoader):
         if isinstance(attr, bytes):
             attr = attr.decode()
 
+        if isinstance(attr, np.ndarray):
+            if attr.size == 1:
+                attr = attr.item()
+
         if isinstance(attr, str):
             if "," in attr:
                 attr = [int(i) for i in attr.split(",")]

--- a/peaks/core/process/tools.py
+++ b/peaks/core/process/tools.py
@@ -1172,8 +1172,8 @@ def degrid(data, width=0.1, height=0.1, cutoff=4):
     )
 
     # Ensure n=0 components are unaffected by changing their values in the filter to 1
-    FFT_filter[int(np.where(n1_values == 0)[0])] = 1
-    FFT_filter[:, int(np.where(n2_values == 0)[0])] = 1
+    FFT_filter[int(np.where(n1_values == 0)[0].item())] = 1
+    FFT_filter[:, int(np.where(n2_values == 0)[0].item())] = 1
 
     # Define degrid_data, and assign its contents to the inverse FFT of the original FFT of the data, multiplied by the
     # filter to remove intense high frequency Fourier components


### PR DESCRIPTION
Fixed various issues:

1. `numpy` issue: TypeError in diamond loader `TypeError: only 0-dimensional arrays can be converted to Python scalars` - This is because since v2.4.0 `numpy` requires extracting a single element first when converting an array that is not 0-dimensional to a scalar
2. `xarray` issue - FutureWarnings asking to specify the dimension for `.argmax()` or `.argmin()` calls
3. `plot_nanofocus` issue - When all focus estimates are identical the standard deviation is 0, so the outlier rejection condition is never true and the filtered list just stays empty