### PR TITLE
Pull example cif data from local path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - The slant correction section from the docs, along with the associated function for downloading the related example data
+- `numba` version constraint
 
 ## [0.4.8]
 
@@ -52,7 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Bug when summing two FSMs
-- Pinned numba version to >=0.60.0 to resolve dependency conflicts
+- Pinned `numba` version to >=0.60.0 to resolve dependency conflicts
 - Downloading errors due to rate limiting
 
 ## [0.4.4]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `xarray` warnings about `.argmax()` calls
 - Boundary case in `plot_nanofocus` when all focus estimates are identical and `.std()` is 0
 
+### Added
+
+- Local mirror path support for structure example data, falling back to remote download if unavailable
+
+### Removed
+
+- The slant correction section from the docs, along with the associated function for downloading the related example data
+
 ## [0.4.8]
 
 ### Added

--- a/peaks/core/utils/sample_data.py
+++ b/peaks/core/utils/sample_data.py
@@ -25,7 +25,7 @@ class ZenodoDownloader:
     from the environment variable `ZENODO_TOKEN` if not explicitly provided.
 
     If `LOCAL_MIRROR_PATH` is set, files will be copied from this local directory
-    with Zenodo serving as the fallback  (used in CI)."""
+    with Zenodo serving as the fallback (used in CI)."""
 
     def __init__(self, file_list, token=None):
         self.root_url = ROOT_URL.rstrip("/")
@@ -235,10 +235,6 @@ class ExampleData:
         return cls._get_and_load("i05-1-34301.nxs")
 
     @classmethod
-    def dispersion4(cls):
-        return cls._get_and_load("i05-1-31473.nxs")
-
-    @classmethod
     def gold_reference(cls):
         return cls._get_and_load("i05-59853.nxs")
 
@@ -289,22 +285,30 @@ class ExampleData:
 
     @classmethod
     def structure(cls):
+        """If `LOCAL_MIRROR_PATH` is set, files will be copied from this local directory
+        with the database sever as the fallback (used in CI)."""
         data = cls._cache.get("structure")
         if data is None:
-            url = "https://qiserver.ugr.es/cod/4515175.cif"
-            response = requests.get(url)
-            if response.status_code == 200:
-                with tempfile.NamedTemporaryFile(
-                    "w+", suffix=".cif", delete=True
-                ) as tmp:
-                    tmp.write(response.text)
-                    tmp.flush()
-                    data = load(tmp.name)
-                    cls._cache["structure"] = data
-            else:
-                raise ValueError(
-                    f"Failed to download CIF. HTTP status code: {response.status_code}"
-                )
+            local_mirror = os.getenv("LOCAL_MIRROR_PATH")
+            if local_mirror:
+                local_path = os.path.join(local_mirror, "4515175.cif")
+                if os.path.exists(local_path):
+                    data = load(local_path)
+            if data is None:
+                url = "https://qiserver.ugr.es/cod/4515175.cif"
+                response = requests.get(url)
+                if response.status_code == 200:
+                    with tempfile.NamedTemporaryFile(
+                        "w+", suffix=".cif", delete=True
+                    ) as tmp:
+                        tmp.write(response.text)
+                        tmp.flush()
+                        data = load(tmp.name)
+                else:
+                    raise ValueError(
+                        f"Failed to download CIF. HTTP status code: {response.status_code}"
+                    )
+            cls._cache["structure"] = data
         return deepcopy(data)
 
     @classmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
         "natsort (>=8.4,<9)",
         "igor2 (>=0.5,<1)",
         "jupyterlab (>=4.2,<5)",
-        "numba (>=0.60.0)",
         "numbagg (>=0.8,<1)",
         "numba-progress (>=1.1,<2)",
         "numexpr (>=2.10, <3)",

--- a/tutorials/7_nanoARPES.ipynb
+++ b/tutorials/7_nanoARPES.ipynb
@@ -462,40 +462,7 @@
     }
    },
    "source": [
-    "## Diamond I05-nano additional options\n",
-    "### Slant correction\n",
-    "At I05-nano, at least during the beamtimes in 2021 and 2022, the Scienta DA30 has a weird slant on the detector. This can be removed during loading by calling the loader with the custom option `slant_correct=True`, and optionally providing a factor (`slant_factor=`). If no `slant_factor` is provided, the default value of 8/PE deg/eV is used.Alternatively, the accessor `.slant_correct` can be used to apply this to already loaded data."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "disp_orig = ExampleData.dispersion4()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "disp_sl_corr = disp_orig.slant_correct()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pks.plot_grid([disp_orig, disp_sl_corr], titles=['Original', 'Slant correct'])"
+    "## Diamond I05-nano additional options"
    ]
   },
   {


### PR DESCRIPTION
As described in the title, and remove the redundant `numba` version constraint and the slant correction part in the docs for diamond data collected within that specific time window