### PR TITLE
fix OpticsMetadataModel serialisation for additional optics axes

### DIFF
--- a/peaks/core/metadata/base_metadata_models.py
+++ b/peaks/core/metadata/base_metadata_models.py
@@ -3,7 +3,7 @@ from typing import Optional, Union
 import numpy as np
 import pint
 import pint_xarray
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 from pydantic_core import core_schema
 
 # Define the appropriate unit registry
@@ -145,6 +145,10 @@ class TemperatureMetadataModel(BaseMetadataModel):
 # Define the optics metadata model
 class OpticsMetadataModel(BaseMetadataModel):
     """Model to store optics metadata."""
+
+    __pydantic_extra__: dict[str, NamedAxisMetadataModel] = Field(
+        init=False
+    )  # enforce extra fields to be of type NamedAxisMetadataModel for serialisation
 
     model_config = ConfigDict(extra="allow")
 

--- a/peaks/core/utils/sample_data.py
+++ b/peaks/core/utils/sample_data.py
@@ -15,7 +15,7 @@ from urllib3.util.retry import Retry
 from peaks.core.fileIO.data_loading import load
 from peaks.core.utils.misc import analysis_warning
 
-ROOT_URL = "https://zenodo.org/api/records/15928652/files"
+ROOT_URL = "https://zenodo.org/api/records/19336694/files"
 
 
 class ZenodoDownloader:


### PR DESCRIPTION
As per the title. And update the zenodo URL for the spatial map example data which were saved by peaks before with the deprecated `I05NanoFocussingMetadataModel` metadata