### PR TITLE
Fixed issue #19 - can't reload data saved by peaks without parsing metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Error when loading NetCDF files saved by `peaks` with `metadata=False`.
+- Errors when loading NetCDF files and processing Zarr files saved by `peaks` with `metadata=False` ([PR#20](https://github.com/phrgab/peaks/pull/20))
 
 ## [0.5.0] - 2026-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1.dev]
+
+### Fixed
+
+- Error when loading NetCDF files saved by `peaks` with `metadata=False`.
+
 ## [0.5.0] - 2026-04-23
 
 ### Added

--- a/peaks/core/fileIO/loaders/netcdf.py
+++ b/peaks/core/fileIO/loaders/netcdf.py
@@ -11,6 +11,7 @@ from peaks.core.fileIO.base_data_classes.base_data_class import BaseDataLoader
 from peaks.core.fileIO.loc_registry import register_loader
 from peaks.core.metadata.base_metadata_models import AxisMetadataModelWithReference
 from peaks.core.options import opts
+from peaks.core.utils.misc import analysis_warning
 
 
 # Classes for data loaders
@@ -52,9 +53,16 @@ class NetCDFLoader(BaseDataLoader):
         except ValueError:
             data = xr.open_dataset(fpath)
 
-        # Parse the metadata if requested
-        if metadata:
-            cls._parse_metadata(data)
+        # Parse the metadata
+        cls._parse_metadata(data)
+
+        if metadata is False and not quiet:
+            analysis_warning(
+                "`metadata=False` option has no effect when loading NetCDF files. "
+                "Metadata are always parsed from saved files.",
+                title="Loading info",
+                warn_type="info",
+            )
 
         # Actually load the data
         if (lazy is False) or (lazy is None and data.nbytes > opts.FileIO.lazy_size):

--- a/peaks/core/fileIO/loaders/zarr.py
+++ b/peaks/core/fileIO/loaders/zarr.py
@@ -40,9 +40,16 @@ class ZarrLoader(NetCDFLoader):
         # Load Zarr file as xarray.DataArray or xarray.Dataset
         data = open_datatree(fpath, engine="zarr", chunks={})
 
-        # Parse the metadata if requested
-        if metadata:
-            data = data.map_over_datasets(ZarrLoader._parse_ds_metadata)
+        # Parse the metadata
+        data = data.map_over_datasets(ZarrLoader._parse_ds_metadata)
+
+        if metadata is False and not quiet:
+            analysis_warning(
+                "`metadata=False` option has no effect when loading NetCDF files. "
+                "Metadata are always parsed from saved files.",
+                title="Loading info",
+                warn_type="info",
+            )
 
         # Quantify the data
         data = data.map_over_datasets(ZarrLoader._quantify_da_in_dt)

--- a/peaks/core/fileIO/loaders/zarr.py
+++ b/peaks/core/fileIO/loaders/zarr.py
@@ -45,7 +45,7 @@ class ZarrLoader(NetCDFLoader):
 
         if metadata is False and not quiet:
             analysis_warning(
-                "`metadata=False` option has no effect when loading NetCDF files. "
+                "`metadata=False` option has no effect when loading Zarr files. "
                 "Metadata are always parsed from saved files.",
                 title="Loading info",
                 warn_type="info",


### PR DESCRIPTION
Fix #19 

## Changes

`NetCDFLoader._load` now always calls `_parse_metadata` irrespective of the `metadata` flag with an info warning issued when `metadata=False` is passed.

## Reasoning

When loading NetCDF files, it always calls `cls._add_load_history` --> `.history.add` -> `_update_hist` --> `add_record`. The final `add_record` is then called on a string if `metadata=False` which has no idea of the `AnalysisHistoryRecord` class.

For saved data, metadata should have already been parsed and validated when the data were originally loaded. No gain from skipping metadata parsing?