### PR TITLE
Add support for opening multiple `disp` panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Demo video showing how to use the ROI panel in the 4D GUI ([PR#30](https://github.com/phrgab/peaks/pull/30))
 - D101 and D103 to `ruff` linting rules to enforce docstrings on public classes and functions ([PR#30](https://github.com/phrgab/peaks/pull/30))
 - numpy convention to `ruff` linting ([PR#30](https://github.com/phrgab/peaks/pull/30))
+- support for opening multiple `disp` panels simultaneously in Jupyter environments when `%gui qt6` is enabled ([PR#34](https://github.com/phrgab/peaks/pull/34))
 
 ### Fixed
 

--- a/peaks/core/GUI/disp_panels/disp_2d.py
+++ b/peaks/core/GUI/disp_panels/disp_2d.py
@@ -57,10 +57,10 @@ def _disp_2d(data, primary_dim, exclude_from_centering):
     # fire a warning if there are already 3 or more disp panels open
     if len(active_viewers) >= 3:
         analysis_warning(
-            f"There are currenly {len(active_viewers)} active display panels. "
+            f"There are currently {len(active_viewers)} active display panels. "
             "This may cause performance issues.",
             warn_type="warning",
-            title="Multiple dispaly panels open",
+            title="Multiple display panels open",
         )
 
     viewer.destroyed.connect(

--- a/peaks/core/GUI/disp_panels/disp_2d.py
+++ b/peaks/core/GUI/disp_panels/disp_2d.py
@@ -64,9 +64,9 @@ def _disp_2d(data, primary_dim, exclude_from_centering):
         )
 
     viewer.destroyed.connect(
-        lambda *_: active_viewers.remove(viewer)
-        if viewer in active_viewers
-        else None  # Remove viewer from active viewers list when it is closed
+        lambda *_: (
+            active_viewers.remove(viewer) if viewer in active_viewers else None
+        )  # Remove viewer from active viewers list when it is closed
     )
     viewer.show()
 

--- a/peaks/core/GUI/disp_panels/disp_2d.py
+++ b/peaks/core/GUI/disp_panels/disp_2d.py
@@ -24,8 +24,7 @@ from peaks.core.GUI.GUI_utils import (
 from peaks.core.GUI.GUI_utils.cursor_stats import _parse_norm_emission_cursor_stats
 from peaks.core.metadata.metadata_methods import display_metadata
 from peaks.core.process.tools import estimate_sym_point, sym
-
-_active_viewers: list = []  # to store active viewer instances and prevent garbage collection
+from peaks.core.utils.misc import analysis_warning
 
 
 def _disp_2d(data, primary_dim, exclude_from_centering):
@@ -48,27 +47,28 @@ def _disp_2d(data, primary_dim, exclude_from_centering):
     if app is None:
         app = QApplication(sys.argv)
 
+    if not hasattr(app, "_peaks_active_viewers"):
+        app._peaks_active_viewers = []
+    active_viewers = app._peaks_active_viewers
+
     viewer = _Disp2D(data, primary_dim, exclude_from_centering)
-    _active_viewers.append(viewer)  # add the viewer to active viewers list
+    active_viewers.append(viewer)  # add the viewer to active viewers list
+
+    # fire a warning if there are already 3 or more disp panels open
+    if len(active_viewers) >= 3:
+        analysis_warning(
+            f"There are currenly {len(active_viewers)} active display panels. "
+            "This may cause performance issues.",
+            warn_type="warning",
+            title="Multiple dispaly panels open",
+        )
+
     viewer.destroyed.connect(
-        lambda *_: _active_viewers.remove(viewer)
-        if viewer in _active_viewers
+        lambda *_: active_viewers.remove(viewer)
+        if viewer in active_viewers
         else None  # Remove viewer from active viewers list when it is closed
     )
     viewer.show()
-
-    # try:
-    #     from IPython import get_ipython
-
-    #     ip = get_ipython()
-    #     print(f"ipython event loop is {ip.active_eventloop}")
-    #     if ip is not None:
-    #         if getattr(ip, "active_eventloop", None) is None:
-    #             ip.enable_gui("qt6")
-    #             print(f"ipython event loop integration is enabled for qt: {ip.active_eventloop}")
-    #         return
-    # except Exception:
-    #     pass
 
     # to support multiple display panels
     try:
@@ -82,7 +82,7 @@ def _disp_2d(data, primary_dim, exclude_from_centering):
         pass
 
     # fallback to Qt event loop if not in IPython or if IPYthon does not have an active event loop
-    if not any(v.isVisible() for v in _active_viewers if v is not viewer):
+    if not any(v.isVisible() for v in active_viewers if v is not viewer):
         app.exec()
 
 

--- a/peaks/core/GUI/disp_panels/disp_2d.py
+++ b/peaks/core/GUI/disp_panels/disp_2d.py
@@ -25,6 +25,8 @@ from peaks.core.GUI.GUI_utils.cursor_stats import _parse_norm_emission_cursor_st
 from peaks.core.metadata.metadata_methods import display_metadata
 from peaks.core.process.tools import estimate_sym_point, sym
 
+_active_viewers: list = []  # to store active viewer instances and prevent garbage collection
+
 
 def _disp_2d(data, primary_dim, exclude_from_centering):
     """Display a 2D interactive display panel.
@@ -47,8 +49,41 @@ def _disp_2d(data, primary_dim, exclude_from_centering):
         app = QApplication(sys.argv)
 
     viewer = _Disp2D(data, primary_dim, exclude_from_centering)
+    _active_viewers.append(viewer)  # add the viewer to active viewers list
+    viewer.destroyed.connect(
+        lambda *_: _active_viewers.remove(viewer)
+        if viewer in _active_viewers
+        else None  # Remove viewer from active viewers list when it is closed
+    )
     viewer.show()
-    app.exec()
+
+    # try:
+    #     from IPython import get_ipython
+
+    #     ip = get_ipython()
+    #     print(f"ipython event loop is {ip.active_eventloop}")
+    #     if ip is not None:
+    #         if getattr(ip, "active_eventloop", None) is None:
+    #             ip.enable_gui("qt6")
+    #             print(f"ipython event loop integration is enabled for qt: {ip.active_eventloop}")
+    #         return
+    # except Exception:
+    #     pass
+
+    # to support multiple display panels
+    try:
+        from IPython import get_ipython
+
+        ip = get_ipython()
+        if ip is not None:
+            if getattr(ip, "active_eventloop", None) == "qt6":
+                return
+    except Exception:
+        pass
+
+    # fallback to Qt event loop if not in IPython or if IPYthon does not have an active event loop
+    if not any(v.isVisible() for v in _active_viewers if v is not viewer):
+        app.exec()
 
 
 class _Disp2D(QtWidgets.QMainWindow):
@@ -121,9 +156,9 @@ class _Disp2D(QtWidgets.QMainWindow):
         self.closeEvent = self._close_application
 
     def _close_application(self, event):
-        """Close the application when the window is closed."""
+        """Close the application when the window is closed without shutting down the event loop."""
         self.graphics_layout.close()
-        app.quit()
+        event.accept()
 
     # ##############################
     # GUI layout

--- a/peaks/core/GUI/disp_panels/disp_3d.py
+++ b/peaks/core/GUI/disp_panels/disp_3d.py
@@ -63,9 +63,9 @@ def _disp_3d(data, primary_dim, exclude_from_centering):
         )
 
     viewer.destroyed.connect(
-        lambda *_: active_viewers.remove(viewer)
-        if viewer in active_viewers
-        else None  # Remove viewer from active viewers list when it is closed
+        lambda *_: (
+            active_viewers.remove(viewer) if viewer in active_viewers else None
+        )  # Remove viewer from active viewers list when it is closed
     )
     viewer.show()
 

--- a/peaks/core/GUI/disp_panels/disp_3d.py
+++ b/peaks/core/GUI/disp_panels/disp_3d.py
@@ -23,8 +23,7 @@ from peaks.core.GUI.GUI_utils import (
 from peaks.core.GUI.GUI_utils.cursor_stats import _parse_norm_emission_cursor_stats
 from peaks.core.metadata.metadata_methods import display_metadata
 from peaks.core.process.tools import estimate_sym_point, sym
-
-_active_viewers: list = []  # to store active viewer instances and prevent garbage collection
+from peaks.core.utils.misc import analysis_warning
 
 
 def _disp_3d(data, primary_dim, exclude_from_centering):
@@ -47,11 +46,25 @@ def _disp_3d(data, primary_dim, exclude_from_centering):
     if app is None:
         app = QApplication(sys.argv)
 
+    if not hasattr(app, "_peaks_active_viewers"):
+        app._peaks_active_viewers = []
+    active_viewers = app._peaks_active_viewers
+
     viewer = _Disp3D(data, primary_dim, exclude_from_centering)
-    _active_viewers.append(viewer)
+    active_viewers.append(viewer)
+
+    # fire a warning if there are already 3 or more disp panels open
+    if len(active_viewers) >= 3:
+        analysis_warning(
+            f"There are currenly {len(active_viewers)} active display panels. "
+            "This may cause performance issues.",
+            warn_type="warning",
+            title="Multiple dispaly panels open",
+        )
+
     viewer.destroyed.connect(
-        lambda *_: _active_viewers.remove(viewer)
-        if viewer in _active_viewers
+        lambda *_: active_viewers.remove(viewer)
+        if viewer in active_viewers
         else None  # Remove viewer from active viewers list when it is closed
     )
     viewer.show()
@@ -68,7 +81,7 @@ def _disp_3d(data, primary_dim, exclude_from_centering):
         pass
 
     # fallback to Qt event loop if not in IPython or if IPYthon does not have an active event loop
-    if not any(v.isVisible() for v in _active_viewers if v is not viewer):
+    if not any(v.isVisible() for v in active_viewers if v is not viewer):
         app.exec()
 
 

--- a/peaks/core/GUI/disp_panels/disp_3d.py
+++ b/peaks/core/GUI/disp_panels/disp_3d.py
@@ -24,6 +24,8 @@ from peaks.core.GUI.GUI_utils.cursor_stats import _parse_norm_emission_cursor_st
 from peaks.core.metadata.metadata_methods import display_metadata
 from peaks.core.process.tools import estimate_sym_point, sym
 
+_active_viewers: list = []  # to store active viewer instances and prevent garbage collection
+
 
 def _disp_3d(data, primary_dim, exclude_from_centering):
     """Display a 3D interactive display panel.
@@ -46,8 +48,28 @@ def _disp_3d(data, primary_dim, exclude_from_centering):
         app = QApplication(sys.argv)
 
     viewer = _Disp3D(data, primary_dim, exclude_from_centering)
+    _active_viewers.append(viewer)
+    viewer.destroyed.connect(
+        lambda *_: _active_viewers.remove(viewer)
+        if viewer in _active_viewers
+        else None  # Remove viewer from active viewers list when it is closed
+    )
     viewer.show()
-    app.exec()
+
+    # to support multiple display panels
+    try:
+        from IPython import get_ipython
+
+        ip = get_ipython()
+        if ip is not None:
+            if getattr(ip, "active_eventloop", None) == "qt6":
+                return
+    except Exception:
+        pass
+
+    # fallback to Qt event loop if not in IPython or if IPYthon does not have an active event loop
+    if not any(v.isVisible() for v in _active_viewers if v is not viewer):
+        app.exec()
 
 
 class _Disp3D(QtWidgets.QMainWindow):
@@ -114,9 +136,9 @@ class _Disp3D(QtWidgets.QMainWindow):
         self.closeEvent = self._close_application
 
     def _close_application(self, event):
-        """Close the application when the window is closed."""
+        """Close the application when the window is closed without shutting down the event loop."""
         self.graphics_layout.close()
-        app.quit()
+        event.accept()
 
     # ##############################
     # GUI layout

--- a/peaks/core/GUI/disp_panels/disp_3d.py
+++ b/peaks/core/GUI/disp_panels/disp_3d.py
@@ -56,10 +56,10 @@ def _disp_3d(data, primary_dim, exclude_from_centering):
     # fire a warning if there are already 3 or more disp panels open
     if len(active_viewers) >= 3:
         analysis_warning(
-            f"There are currenly {len(active_viewers)} active display panels. "
+            f"There are currently {len(active_viewers)} active display panels. "
             "This may cause performance issues.",
             warn_type="warning",
-            title="Multiple dispaly panels open",
+            title="Multiple display panels open",
         )
 
     viewer.destroyed.connect(

--- a/peaks/core/GUI/disp_panels/disp_4d.py
+++ b/peaks/core/GUI/disp_panels/disp_4d.py
@@ -16,13 +16,13 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
+from peaks.core.utils.misc import analysis_warning
+
 from ..GUI_utils import (
     Crosshair,
     KeyPressGraphicsLayoutWidget,
 )
 from .disp_2d import _Disp2D
-
-_active_viewers: list = []  # to store active viewer instances and prevent garbage collection
 
 
 def _disp_4d(data, primary_dim):
@@ -42,10 +42,24 @@ def _disp_4d(data, primary_dim):
     if app is None:
         app = QApplication(sys.argv)
 
+    if not hasattr(app, "_peaks_active_viewers"):
+        app._peaks_active_viewers = []
+    active_viewers = app._peaks_active_viewers
+
     viewer = _Disp4D(data, primary_dim)
-    _active_viewers.append(viewer)
+    active_viewers.append(viewer)
+
+    # fire a warning if there are already 3 or more disp panels open
+    if len(active_viewers) >= 3:
+        analysis_warning(
+            f"There are currenly {len(active_viewers)} active display panels. "
+            "This may cause performance issues.",
+            warn_type="warning",
+            title="Multiple dispaly panels open",
+        )
+
     viewer.destroyed.connect(
-        lambda *_: _active_viewers.remove(viewer) if viewer in _active_viewers else None
+        lambda *_: active_viewers.remove(viewer) if viewer in active_viewers else None
     )
     viewer.show()
 
@@ -61,7 +75,7 @@ def _disp_4d(data, primary_dim):
         pass
 
     # fallback to Qt event loop if not in IPython or if IPYthon does not have an active event loop
-    if not any(v.isVisible() for v in _active_viewers if v is not viewer):
+    if not any(v.isVisible() for v in active_viewers if v is not viewer):
         app.exec()
 
 
@@ -80,8 +94,7 @@ class _Disp4D(QtWidgets.QMainWindow):
         # Set up the GUI
         self._init_UI()  # Initialize the layout
 
-        # clean up the widget on close, but don't quit the global app.
-        # https://doc.qt.io/qt-6/qt.html#WidgetAttribute-enum
+        # Clean up the widget on close, but don't quit the global app.
         self.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose)
         self.closeEvent = lambda event: event.accept()
 

--- a/peaks/core/GUI/disp_panels/disp_4d.py
+++ b/peaks/core/GUI/disp_panels/disp_4d.py
@@ -22,6 +22,8 @@ from ..GUI_utils import (
 )
 from .disp_2d import _Disp2D
 
+_active_viewers: list = []  # to store active viewer instances and prevent garbage collection
+
 
 def _disp_4d(data, primary_dim):
     """Display a 4D interactive display panel.
@@ -41,8 +43,26 @@ def _disp_4d(data, primary_dim):
         app = QApplication(sys.argv)
 
     viewer = _Disp4D(data, primary_dim)
+    _active_viewers.append(viewer)
+    viewer.destroyed.connect(
+        lambda *_: _active_viewers.remove(viewer) if viewer in _active_viewers else None
+    )
     viewer.show()
-    app.exec()
+
+    # to support multiple display panels
+    try:
+        from IPython import get_ipython
+
+        ip = get_ipython()
+        if ip is not None:
+            if getattr(ip, "active_eventloop", None) == "qt6":
+                return
+    except Exception:
+        pass
+
+    # fallback to Qt event loop if not in IPython or if IPYthon does not have an active event loop
+    if not any(v.isVisible() for v in _active_viewers if v is not viewer):
+        app.exec()
 
 
 class _Disp4D(QtWidgets.QMainWindow):
@@ -59,6 +79,11 @@ class _Disp4D(QtWidgets.QMainWindow):
 
         # Set up the GUI
         self._init_UI()  # Initialize the layout
+
+        # clean up the widget on close, but don't quit the global app.
+        # https://doc.qt.io/qt-6/qt.html#WidgetAttribute-enum
+        self.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose)
+        self.closeEvent = lambda event: event.accept()
 
     # ##############################
     # GUI layout

--- a/peaks/core/GUI/disp_panels/disp_4d.py
+++ b/peaks/core/GUI/disp_panels/disp_4d.py
@@ -52,10 +52,10 @@ def _disp_4d(data, primary_dim):
     # fire a warning if there are already 3 or more disp panels open
     if len(active_viewers) >= 3:
         analysis_warning(
-            f"There are currenly {len(active_viewers)} active display panels. "
+            f"There are currently {len(active_viewers)} active display panels. "
             "This may cause performance issues.",
             warn_type="warning",
-            title="Multiple dispaly panels open",
+            title="Multiple display panels open",
         )
 
     viewer.destroyed.connect(

--- a/tutorials/2_plotting_data.ipynb
+++ b/tutorials/2_plotting_data.ipynb
@@ -276,6 +276,8 @@
     "\n",
     "By default, `peaks` allows only one display panel to open at a time. In a Jupyter notebook, it is possbile to open multiple ones simultaneously by integrating IPython with the Qt event loop. To enable this, run `%gui qt6` once in the notebook, typically alongside the `peaks` import. NB it must be run after `%matplotlib inline` (if present)  which otherwise resets the event loop. Running many display panels at once may impact responsiveness and consume memory. Run `%gui` to disable it.\n",
     "\n",
+    "When a display panel opens, its window may appear behind the active browser window.\n",
+    "\n",
     ":::"
    ]
   },

--- a/tutorials/2_plotting_data.ipynb
+++ b/tutorials/2_plotting_data.ipynb
@@ -269,7 +269,14 @@
     "```python\n",
     "# Show an explorer view of multiple 2D DataArrays stored in a DataTree `dt`\n",
     "dt.disp()  # Open the viewer\n",
-    "```"
+    "```\n",
+    "\n",
+    ":::{admonition} Multiple display panels\n",
+    ":class: note\n",
+    "\n",
+    "By default, `peaks` allows only one display panel to open at a time. In a Jupyter notebook, it is possbile to open multiple ones simultaneously by integrating IPython with the Qt event loop. To enable this, run `%gui qt6` once in the notebook, typically alongside the `peaks` import. NB it must be run after `%matplotlib inline` (if present)  which otherwise resets the event loop. Running many display panels at once may impact responsiveness and consume memory. Run `%gui` to disable it.\n",
+    "\n",
+    ":::"
    ]
   },
   {


### PR DESCRIPTION
Currently only one display panel can be opened at a time in `peaks`. This is because `_disp_2d`, `_disp_3d` and `_disp_4d` each call `app.exec()`, activating a Qt event loop and hanging the calling cell until the window is closed.

While this is sensible, e.g. during a beamtime, to ensure the sample is aligned based on the GUI showing the latest data rather than a stale one left over in the background, it's a bit of a faff when running through a long notebook with uncommented `disp` cells as the GUI blocks subsequent cells.

This PR is a hotfix that allows multiple display panels to be open simultaneously - hotfix in the sense that it only works in jupyter notebooks since under the hood it takes advantage of [ipython's relevant magic commands](https://ipython.readthedocs.io/en/stable/interactive/magics.html#magic-gui) which allow [integrating ipykernel's loop with Qt event loop](https://ipython.readthedocs.io/en/stable/config/eventloops.html). It can be enabled by running `%gui qt6` and disabled by `%gui`, as documented in the user guide. If the integration is not enabled, the function falls back to the default one-panel behaviour. A warning pops up if 3 or more panels are active.

In the close handler, I also changed `app.quit()` to `event.accept()`, which basically acknowledges the close signal and closes the window without shutting down the qt event loop. It seems that [Qt's default behaviour](https://doc.qt.io/qt-6/qguiapplication.html#quitOnLastWindowClosed-prop) handles loop exit automatically once the last visible window closes. This seems to have fixed the ghost window issue that sometimes appeared at least on macos.

This enhancement was suggested in the issue #29.