### PR TITLE
Fix broken metadata colour encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,14 +14,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - conda-forge package publishing
 - Demo video showing how to use the ROI panel in the 4D GUI ([PR#30](https://github.com/phrgab/peaks/pull/30))
 - D101, D102, D103 and D104 to `ruff` linting rules to enforce docstrings on public classes, methods, functions and packages ([PR#30](https://github.com/phrgab/peaks/pull/30))
-- numpy convention to `ruff` linting ([PR#30](https://github.com/phrgab/peaks/pull/30))
-- support for opening multiple `disp` panels simultaneously in Jupyter environments when `%gui qt6` is enabled ([PR#34](https://github.com/phrgab/peaks/pull/34))
+- NumPy convention to `ruff` linting ([PR#30](https://github.com/phrgab/peaks/pull/30))
+- Support for opening multiple `disp` panels simultaneously in Jupyter environments when `%gui qt6` is enabled ([PR#34](https://github.com/phrgab/peaks/pull/34))
+- `_repr_html_` methods in the `Metadata` and `MetadataItem` classes, providing proper colour-coded HTML display of `da.metadata` and `da.metadata.<key>` in IPython-compatible environments ([PR#35](https://github.com/phrgab/peaks/pull/35))
+- More unit tests for colour-encoded metadata display `core/metadata`: `metadata_method` ([PR#35](https://github.com/phrgab/peaks/pull/35))
 
 ### Fixed
 
 - Errors when loading NetCDF files and processing Zarr files saved by `peaks` with `metadata=False` ([PR#20](https://github.com/phrgab/peaks/pull/20))
 - Error when calling `plot_tutorial_example_figure` locally ([PR#28](https://github.com/phrgab/peaks/pull/28))
 - Empty inline interactive `iplot` when using the `groupby` argument in static CI docs builds ([PR#30](https://github.com/phrgab/peaks/pull/30))
+- Colour-coded metadata rendering in docs ([PR#35](https://github.com/phrgab/peaks/pull/35))
 
 ### Changed
 
@@ -29,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Installation instructions now cover `uv`, conda-forge and the traditional Python venv approach ([PR#28](https://github.com/phrgab/peaks/pull/28))
 - `plot_tutorial_example_figure` now renders videos ([PR#30](https://github.com/phrgab/peaks/pull/30))
 - Figure aspect ratios in output cells are preserved on docs build ([PR#30](https://github.com/phrgab/peaks/pull/30))
+- `display_metadata` now takes an optional `palette` argument and the default `mode` is now `"HTML"` (was `"ANSI"`) ([PR#35](https://github.com/phrgab/peaks/pull/35))
 
 ### Removed
 

--- a/peaks/core/GUI/disp_panels/disp_2d.py
+++ b/peaks/core/GUI/disp_panels/disp_2d.py
@@ -22,7 +22,7 @@ from peaks.core.GUI.GUI_utils import (
     KeyPressGraphicsLayoutWidget,
 )
 from peaks.core.GUI.GUI_utils.cursor_stats import _parse_norm_emission_cursor_stats
-from peaks.core.metadata.metadata_methods import display_metadata
+from peaks.core.metadata.metadata_methods import DARK_BG_PALETTE, display_metadata
 from peaks.core.process.tools import estimate_sym_point, sym
 from peaks.core.utils.misc import analysis_warning
 
@@ -383,7 +383,7 @@ class _Disp2D(QtWidgets.QMainWindow):
 
         # Read scan metadata
         self.metadata_text = "<span style='color:white'>"
-        self.metadata_text += display_metadata(self.current_data, "html")
+        self.metadata_text += display_metadata(self.current_data, DARK_BG_PALETTE)
         self.metadata_text += "</span><br>"
 
     def _set_main_plot(self, cmap, c_range, xh_pos):

--- a/peaks/core/GUI/disp_panels/disp_3d.py
+++ b/peaks/core/GUI/disp_panels/disp_3d.py
@@ -21,7 +21,7 @@ from peaks.core.GUI.GUI_utils import (
     KeyPressGraphicsLayoutWidget,
 )
 from peaks.core.GUI.GUI_utils.cursor_stats import _parse_norm_emission_cursor_stats
-from peaks.core.metadata.metadata_methods import display_metadata
+from peaks.core.metadata.metadata_methods import DARK_BG_PALETTE, display_metadata
 from peaks.core.process.tools import estimate_sym_point, sym
 from peaks.core.utils.misc import analysis_warning
 
@@ -101,7 +101,7 @@ class _Disp3D(QtWidgets.QMainWindow):
 
         # Read scan metadata
         self.metadata_text = "<span style='color:white'>"
-        self.metadata_text += display_metadata(self.data, "html")
+        self.metadata_text += display_metadata(self.data, DARK_BG_PALETTE)
         self.metadata_text += "</span><br>"
 
         # Crosshair options
@@ -437,7 +437,7 @@ class _Disp3D(QtWidgets.QMainWindow):
 
         # Attempt to read some metadata
         self.metadata_text = "<span style='color:white'>"
-        self.metadata_text += display_metadata(self.data, "html")
+        self.metadata_text += display_metadata(self.data, DARK_BG_PALETTE)
         self.metadata_text += "</span><br>"
 
     def _set_main_plots(self):

--- a/peaks/core/metadata/metadata_methods.py
+++ b/peaks/core/metadata/metadata_methods.py
@@ -14,50 +14,90 @@ from peaks.core.utils.datatree_utils import _map_over_dt_containing_single_das
 
 ureg = pint_xarray.unit_registry
 
+# Paul Tol's muted colour scheme; good for black/dark backgrounds
+# https://sronpersonalpages.nl/~pault/
+# Used in GUI
+DARK_BG_PALETTE = [
+    "#DDCC77",  # sand
+    "#88CCEE",  # cyan
+    "#CC6677",  # rose
+    "#44AA99",  # teal
+]
 
-def display_metadata(da_or_model, mode="ANSI"):
-    """Recursive function to display dictionary with coloured keys."""
-    # Paul Tol's colour scheme
-    colours = [
-        "\x1b[38;2;187;85;0m",  # orange
-        "\x1b[38;2;0;90;181m",  # blue
-        "\x1b[38;2;212;17;89m",  # magenta
-        "\x1b[38;2;0;133;119m",  # green
-    ]
-    RESET = "\x1b[0m"
+# Custom colour scheme. Optimised for white/light backgrounds
+# but still legible on dark backgrounds
+# Used in notebooks
+LIGHT_BG_PALETTE = [
+    "#BB5500",  # orange
+    "#005AB5",  # blue
+    "#D41159",  # magenta
+    "#008577",  # green
+]
 
-    # Recursive function to display dictionary with cycling colors for each indent level
-    def display_colored_dict(d, indent_level=0, col_cycle=0):
-        indent = "    " * indent_level
-        current_color = colours[col_cycle % len(colours)]  # Cycle through colors
+
+def display_metadata(da_or_model, palette=None, mode="HTML"):
+    """Render metadata as a colour-coded nested structure.
+
+    Parameters
+    ----------
+    da_or_model : xarray.DataArray or pydantic.BaseModel or dict
+        The object whose metadata is to be displayed.
+    palette : list of str, optional
+        Hex colour codes to cycle through, one per nesting level.
+        Default to :data:`LIGHT_BG_PALETTE`.
+    mode : {"HTML", "ANSI"}, optional
+        Output format. ``"HTML"`` for notebooks/docs; ``"ANSI"`` for terminal output.
+        Defaults to ``"HTML"``.
+
+    Returns
+    -------
+    str
+        The formatted metadata.
+    """
+
+    if palette is None:
+        palette = LIGHT_BG_PALETTE
+
+    # Recursive function to display dictionary with cycling colours for each indent level
+    def display_coloured_dict_html(d, indent_level=0, col_cycle=0):
+        indent = "&nbsp;" * 4 * indent_level
+        current_colour = palette[col_cycle % len(palette)]  # Cycle through colors
         lines = []
         for key, value in d.items():
             if isinstance(value, dict):  # Nested dictionary (recursive case)
-                lines.append(f"{indent}{current_color}{key}{RESET}:")
+                lines.append(
+                    f"{indent}<span style='color:{current_colour}'>{key}:</span>"
+                )
                 lines.extend(
-                    display_colored_dict(value, indent_level + 1, col_cycle + 1)
+                    display_coloured_dict_html(value, indent_level + 1, col_cycle + 1)
                 )
             else:  # Base case (simple value)
-                lines.append(f"{indent}{current_color}{key}{RESET}: {value}")
+                lines.append(
+                    f"{indent}<span style='color:{current_colour}'>{key}:</span> {value}"
+                )
         return lines
 
-    def display_colored_dict_html(d, indent_level=0, col_cycle=0):
-        indent = "&nbsp;" * 4 * indent_level
-        colours = ["#DDCC77", "#88CCEE", "#CC6677", "#44AA99"]
-        current_color = colours[col_cycle % len(colours)]  # Cycle through colors
+    def _hex_to_rgb(hex_col):
+        hex_col = hex_col.lstrip("#")
+        return tuple(int(hex_col[i : i + 2], 16) for i in (0, 2, 4))
+
+    ansi_colours = [f"\x1b[38;2;{r};{g};{b}m" for (r, g, b) in map(_hex_to_rgb, palette)]
+    RESET = "\x1b[0m"
+
+    def display_coloured_dict_ansi(d, indent_level=0, col_cycle=0):
+        indent = "    " * indent_level
+        current_colour = ansi_colours[
+            col_cycle % len(ansi_colours)
+        ]  # Cycle through colors
         lines = []
         for key, value in d.items():
             if isinstance(value, dict):  # Nested dictionary (recursive case)
-                lines.append(
-                    f"{indent}<span style='color:{current_color}'>{key}:</span>"
-                )
+                lines.append(f"{indent}{current_colour}{key}{RESET}:")
                 lines.extend(
-                    display_colored_dict_html(value, indent_level + 1, col_cycle + 1)
+                    display_coloured_dict_ansi(value, indent_level + 1, col_cycle + 1)
                 )
             else:  # Base case (simple value)
-                lines.append(
-                    f"{indent}<span style='color:{current_color}'>{key}:</span> {value}"
-                )
+                lines.append(f"{indent}{current_colour}{key}{RESET}: {value}")
         return lines
 
     # Display the model with colored keys
@@ -70,9 +110,11 @@ def display_metadata(da_or_model, mode="ANSI"):
     except AttributeError:
         metadata = da_or_model if isinstance(da_or_model, dict) else da_or_model.dict()
     if mode.upper() == "ANSI":
-        return "\n".join(display_colored_dict(metadata))
+        return "\n".join(display_coloured_dict_ansi(metadata))
     elif mode.upper() == "HTML":
-        return "<br>".join(display_colored_dict_html(metadata))
+        return "<br>".join(display_coloured_dict_html(metadata))
+    else:
+        raise ValueError("mode must be 'HTML' or 'ANSI'.")
 
 
 def compare_metadata(da_or_model1, da_or_model2):
@@ -171,6 +213,9 @@ class Metadata:
         self._obj = xarray_obj
 
     def __repr__(self):
+        return display_metadata(self._obj, palette=DARK_BG_PALETTE, mode="ANSI")
+
+    def _repr_html_(self):
         return display_metadata(self._obj)
 
     def __getattr__(self, name):
@@ -559,6 +604,9 @@ class MetadataItem:
         self._obj = obj  # Reference to the parent object
 
     def __repr__(self):
+        return display_metadata(self._data, palette=DARK_BG_PALETTE, mode="ANSI")
+
+    def _repr_html_(self):
         return display_metadata(self._data)
 
     def __getattr__(self, name):

--- a/tests/core/metadata/test_metadata_methods.py
+++ b/tests/core/metadata/test_metadata_methods.py
@@ -1,0 +1,131 @@
+import pytest
+
+from peaks.core.metadata.metadata_methods import (
+    DARK_BG_PALETTE,
+    LIGHT_BG_PALETTE,
+    display_metadata,
+)
+from peaks.core.utils.sample_data import ExampleData
+
+
+@pytest.fixture(scope="session")
+def disp():
+    return ExampleData.dispersion2a()
+
+
+# for testing ANSI output
+# copied from the internal _hex_to_rgb function in metadata_methods
+def _hex_to_rgb(hex_col):
+    hex_col = hex_col.lstrip("#")
+    return tuple(int(hex_col[i : i + 2], 16) for i in (0, 2, 4))
+
+
+class TestDisplayMetadata:
+    def test_colours_applied_to_nesting_levels_html(self, disp):
+        result = display_metadata(disp, mode="HTML")
+        expected_pairs = [
+            (0, "calibration"),
+            (1, "EF_correction"),
+            (2, "lens_mode"),
+            (3, "width"),
+        ]
+        for level, key in expected_pairs:
+            expected = f"<span style='color:{LIGHT_BG_PALETTE[level]}'>{key}:</span>"
+            assert expected in result
+
+    def test_colours_applied_to_nesting_levels_html_dark(self, disp):
+        result = display_metadata(disp, palette=DARK_BG_PALETTE, mode="HTML")
+        expected_pairs = [
+            (0, "calibration"),
+            (1, "EF_correction"),
+            (2, "lens_mode"),
+            (3, "width"),
+        ]
+        for level, key in expected_pairs:
+            expected = f"<span style='color:{DARK_BG_PALETTE[level]}'>{key}:</span>"
+            assert expected in result
+
+    def test_colour_cycling_wraps(self):
+        deep_nesting = {"L0": {"L1": {"L2": {"L3": {"L4": "value"}}}}}
+        result = display_metadata(deep_nesting, mode="HTML")
+        assert result.count(f"color:{LIGHT_BG_PALETTE[0]}") == 2
+        for i in (1, 2, 3):
+            assert result.count(f"color:{LIGHT_BG_PALETTE[i]}") == 1
+        assert f"<span style='color:{LIGHT_BG_PALETTE[0]}'>L0:</span>" in result
+        assert f"<span style='color:{LIGHT_BG_PALETTE[0]}'>L4:</span>" in result
+
+    def test_invalid_mode_raises(self, disp):
+        with pytest.raises(ValueError, match="mode must be"):
+            display_metadata(disp, mode="och")
+
+    def test_colours_applied_to_nesting_levels_ansi(self, disp):
+        result = display_metadata(disp, mode="ANSI")
+        expected_pairs = [
+            (0, "calibration"),
+            (1, "EF_correction"),
+            (2, "lens_mode"),
+            (3, "width"),
+        ]
+        for level, key in expected_pairs:
+            r, g, b = _hex_to_rgb(LIGHT_BG_PALETTE[level])
+            expected = f"\x1b[38;2;{r};{g};{b}m{key}\x1b[0m"
+            assert expected in result
+
+    def test_colours_applied_to_nesting_levels_ansi_dark(self, disp):
+        result = display_metadata(disp, palette=DARK_BG_PALETTE, mode="ANSI")
+        expected_pairs = [
+            (0, "calibration"),
+            (1, "EF_correction"),
+            (2, "lens_mode"),
+            (3, "width"),
+        ]
+        for level, key in expected_pairs:
+            r, g, b = _hex_to_rgb(DARK_BG_PALETTE[level])
+            expected = f"\x1b[38;2;{r};{g};{b}m{key}\x1b[0m"
+            assert expected in result
+
+    def test_colour_cycling_wraps_ansi(self):
+        deep_nesting = {"L0": {"L1": {"L2": {"L3": {"L4": "value"}}}}}
+        result = display_metadata(deep_nesting, palette=DARK_BG_PALETTE, mode="ANSI")
+        r, g, b = _hex_to_rgb(DARK_BG_PALETTE[0])
+        expected_0 = f"\x1b[38;2;{r};{g};{b}m"
+        assert result.count(expected_0) == 2  # used at L0 and L4
+        for i in (1, 2, 3):
+            r, g, b = _hex_to_rgb(DARK_BG_PALETTE[i])
+            expected_i = f"\x1b[38;2;{r};{g};{b}m"
+            assert result.count(expected_i) == 1  # used once each
+
+
+class TestMetadata:
+    def test_repr_returns_ansi(self, disp):
+        result = repr(disp.metadata)
+        assert "\x1b[38;2;" in result  # ANSI escape code
+
+    def test_repr_html_returns_html(self, disp):
+        result = disp.metadata._repr_html_()
+        assert "<span style='color:" in result  # HTML span
+
+    def test_repr_displays_all_metadata(self, disp):
+        result = repr(disp.metadata)
+        for key in ("calibration", "EF_correction", "lens_mode", "width"):
+            assert key in result
+
+
+class TestMetadataItem:
+    def test_repr_returns_ansi(self, disp):
+        result = repr(disp.metadata.calibration)
+        assert "\x1b[38;2;" in result  # ANSI escape code
+
+    def test_repr_html_returns_html(self, disp):
+        result = disp.metadata.calibration._repr_html_()
+        assert "<span style='color:" in result  # HTML span
+
+    def test_repr_only_displays_metadata_item(self, disp):
+        result = repr(disp.metadata.calibration)
+        assert "EF_correction" in result
+        assert "width" not in result
+
+    def test_repr_html_only_displays_metadata_item(self, disp):
+        result = disp.metadata.calibration._repr_html_()
+        assert "EF_correction" in result
+        assert "width" not in result

--- a/tests/core/metadata/test_metadata_methods.py
+++ b/tests/core/metadata/test_metadata_methods.py
@@ -13,6 +13,11 @@ def disp():
     return ExampleData.dispersion2a()
 
 
+@pytest.fixture
+def test_dict():
+    return {"a": {"b": {"c": {"d": {"e": "value"}}}}}
+
+
 # for testing ANSI output
 # copied from the internal _hex_to_rgb function in metadata_methods
 def _hex_to_rgb(hex_col):
@@ -21,72 +26,70 @@ def _hex_to_rgb(hex_col):
 
 
 class TestDisplayMetadata:
-    def test_colours_applied_to_nesting_levels_html(self, disp):
-        result = display_metadata(disp, mode="HTML")
+    def test_colours_applied_to_nesting_levels_html(self, test_dict):
+        result = display_metadata(test_dict, mode="HTML")
         expected_pairs = [
-            (0, "calibration"),
-            (1, "EF_correction"),
-            (2, "lens_mode"),
-            (3, "width"),
+            (0, "a"),
+            (1, "b"),
+            (2, "c"),
+            (3, "d"),
         ]
         for level, key in expected_pairs:
             expected = f"<span style='color:{LIGHT_BG_PALETTE[level]}'>{key}:</span>"
             assert expected in result
 
-    def test_colours_applied_to_nesting_levels_html_dark(self, disp):
-        result = display_metadata(disp, palette=DARK_BG_PALETTE, mode="HTML")
+    def test_colours_applied_to_nesting_levels_html_dark(self, test_dict):
+        result = display_metadata(test_dict, palette=DARK_BG_PALETTE, mode="HTML")
         expected_pairs = [
-            (0, "calibration"),
-            (1, "EF_correction"),
-            (2, "lens_mode"),
-            (3, "width"),
+            (0, "a"),
+            (1, "b"),
+            (2, "c"),
+            (3, "d"),
         ]
         for level, key in expected_pairs:
             expected = f"<span style='color:{DARK_BG_PALETTE[level]}'>{key}:</span>"
             assert expected in result
 
-    def test_colour_cycling_wraps(self):
-        deep_nesting = {"L0": {"L1": {"L2": {"L3": {"L4": "value"}}}}}
-        result = display_metadata(deep_nesting, mode="HTML")
+    def test_colour_cycling_wraps(self, test_dict):
+        result = display_metadata(test_dict, mode="HTML")
         assert result.count(f"color:{LIGHT_BG_PALETTE[0]}") == 2
         for i in (1, 2, 3):
             assert result.count(f"color:{LIGHT_BG_PALETTE[i]}") == 1
-        assert f"<span style='color:{LIGHT_BG_PALETTE[0]}'>L0:</span>" in result
-        assert f"<span style='color:{LIGHT_BG_PALETTE[0]}'>L4:</span>" in result
+        assert f"<span style='color:{LIGHT_BG_PALETTE[0]}'>a:</span>" in result
+        assert f"<span style='color:{LIGHT_BG_PALETTE[0]}'>e:</span>" in result
 
     def test_invalid_mode_raises(self, disp):
         with pytest.raises(ValueError, match="mode must be"):
             display_metadata(disp, mode="och")
 
-    def test_colours_applied_to_nesting_levels_ansi(self, disp):
-        result = display_metadata(disp, mode="ANSI")
+    def test_colours_applied_to_nesting_levels_ansi(self, test_dict):
+        result = display_metadata(test_dict, mode="ANSI")
         expected_pairs = [
-            (0, "calibration"),
-            (1, "EF_correction"),
-            (2, "lens_mode"),
-            (3, "width"),
+            (0, "a"),
+            (1, "b"),
+            (2, "c"),
+            (3, "d"),
         ]
         for level, key in expected_pairs:
             r, g, b = _hex_to_rgb(LIGHT_BG_PALETTE[level])
             expected = f"\x1b[38;2;{r};{g};{b}m{key}\x1b[0m"
             assert expected in result
 
-    def test_colours_applied_to_nesting_levels_ansi_dark(self, disp):
-        result = display_metadata(disp, palette=DARK_BG_PALETTE, mode="ANSI")
+    def test_colours_applied_to_nesting_levels_ansi_dark(self, test_dict):
+        result = display_metadata(test_dict, palette=DARK_BG_PALETTE, mode="ANSI")
         expected_pairs = [
-            (0, "calibration"),
-            (1, "EF_correction"),
-            (2, "lens_mode"),
-            (3, "width"),
+            (0, "a"),
+            (1, "b"),
+            (2, "c"),
+            (3, "d"),
         ]
         for level, key in expected_pairs:
             r, g, b = _hex_to_rgb(DARK_BG_PALETTE[level])
             expected = f"\x1b[38;2;{r};{g};{b}m{key}\x1b[0m"
             assert expected in result
 
-    def test_colour_cycling_wraps_ansi(self):
-        deep_nesting = {"L0": {"L1": {"L2": {"L3": {"L4": "value"}}}}}
-        result = display_metadata(deep_nesting, palette=DARK_BG_PALETTE, mode="ANSI")
+    def test_colour_cycling_wraps_ansi(self, test_dict):
+        result = display_metadata(test_dict, palette=DARK_BG_PALETTE, mode="ANSI")
         r, g, b = _hex_to_rgb(DARK_BG_PALETTE[0])
         expected_0 = f"\x1b[38;2;{r};{g};{b}m"
         assert result.count(expected_0) == 2  # used at L0 and L4
@@ -105,7 +108,7 @@ class TestMetadata:
         result = disp.metadata._repr_html_()
         assert "<span style='color:" in result  # HTML span
 
-    def test_repr_displays_all_metadata(self, disp):
+    def test_repr_displays_all_metadata_keys(self, disp):
         result = repr(disp.metadata)
         for key in ("calibration", "EF_correction", "lens_mode", "width"):
             assert key in result
@@ -120,12 +123,14 @@ class TestMetadataItem:
         result = disp.metadata.calibration._repr_html_()
         assert "<span style='color:" in result  # HTML span
 
-    def test_repr_only_displays_metadata_item(self, disp):
+    def test_repr_only_displays_one_metadata_group(self, disp):
         result = repr(disp.metadata.calibration)
         assert "EF_correction" in result
         assert "width" not in result
+        assert "lens_mode" not in result
 
-    def test_repr_html_only_displays_metadata_item(self, disp):
+    def test_repr_html_only_displays_one_metadata_group(self, disp):
         result = disp.metadata.calibration._repr_html_()
         assert "EF_correction" in result
         assert "width" not in result
+        assert "lens_mode" not in result


### PR DESCRIPTION
Mainly cosmetic changes here.

`display_metadata` wasn't very clean before. So it had ANSI and HTML modes but each mode had a hardcoded colour scheme. Then metadata outputs in jupyter notebooks used ANSI mode with colour scheme 1, a custom set optimised for light backgrounds but adjusted to remain legible on dark backgrounds, while GUIs that always have a black background for metadata display use colour scheme 2.

This was fine for jupyter environments that handle ansi well, but myst-nb doesn't seem to be able to handle 24-bit colours, although it does have an [`AnsiColorLexer`](https://myst-nb.readthedocs.io/en/latest/render/format_code_cells.html#ansi-outputs) supporting 8 ansi colours (That's why basic green can still show up I reckon). As a result, 24-bit colours get stripped during doc builds and come with some noisy literal escape characters in other environments e.g. marimo.

Added `_repr_html_` methods to fix this -
- [IPython supports a list of `_repr_*_()` methods and prefers these over the standard `repr`](https://ipython.readthedocs.io/en/stable/config/integrating.html#rich-display)
- [marimo is compatible with the IPython-style `_repr_*_()` methods](https://docs.marimo.io/guides/integrating_with_marimo/displaying_objects/)
- [`text/html` sits high up in myst-nb's utputs MIME priority](https://myst-nb.readthedocs.io/en/latest/render/format_code_cells.html#outputs-mime-priority)

And it falls back to standard `__repr__` in terminals with ANSI output.

I've also moved the colour schemes out of the function for a bit of flexibility so that any mode can now use any scheme.

Due to the complicated nesting structure of the metadata display, relevant unit tests have also been added.