### PR TITLE
Fixing metadata updates with datatree iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Error when calling `plot_tutorial_example_figure` locally ([PR#28](https://github.com/phrgab/peaks/pull/28))
 - Empty inline interactive `iplot` when using the `groupby` argument in static CI docs builds ([PR#30](https://github.com/phrgab/peaks/pull/30))
 - Colour-coded metadata rendering in docs ([PR#35](https://github.com/phrgab/peaks/pull/35))
+- Bug where analysis history was not updated when iterating accessor methods over a `DataTree` ([PR#39](https://github.com/phrgab/peaks/pull/39))
 
 ### Changed
 
-- Minor documentation improvements and plenty of cosmetic auto-fixes required by numpy-style docstring format ([PR#23](https://github.com/phrgab/peaks/pull/23), [PR#30](https://github.com/phrgab/peaks/pull/30))
+- Minor documentation improvements and plenty of cosmetic auto-fixes required by numpy-style docstring format ([PR#23](https://github.com/phrgab/peaks/pull/23), [PR#30](https://github.com/phrgab/peaks/pull/30), [PR#33](https://github.com/phrgab/peaks/pull/33))
 - Installation instructions now cover `uv`, conda-forge and the traditional Python venv approach ([PR#28](https://github.com/phrgab/peaks/pull/28))
 - `plot_tutorial_example_figure` now renders videos ([PR#30](https://github.com/phrgab/peaks/pull/30))
 - Figure aspect ratios in output cells are preserved on docs build ([PR#30](https://github.com/phrgab/peaks/pull/30))

--- a/peaks/core/accessors/accessor_methods.py
+++ b/peaks/core/accessors/accessor_methods.py
@@ -106,6 +106,16 @@ class PeaksDataTreeIteratorAccessor(PeaksDirectCallAccessor):
         super().__init__(data_tree, module_name, func_name)
         self.data_tree = data_tree  # Overwrite data_array with data_tree
 
+    @staticmethod
+    def _apply_to_single_dataarray_dataset(node, func, *args, **kwargs):
+        """Apply a DataArray-returning function to a single-variable Dataset leaf.
+
+        Rebuild the Dataset from the function output, preserving updated metadata.
+        """
+        data_var_name = next(iter(node.data_vars))
+        updated_da = func(node[data_var_name], *args, **kwargs)
+        return updated_da.to_dataset(name=data_var_name).assign_attrs(node.attrs)
+
     def __call__(self, *args, **kwargs):
         """Iterates over DataTree nodes and applies the function."""
         func = self.func  # Ensure the function is loaded
@@ -115,8 +125,10 @@ class PeaksDataTreeIteratorAccessor(PeaksDirectCallAccessor):
                 # Apply the function to the node directly
                 return func(node, *args, **kwargs)
             elif hasattr(node, "data") and len(node) == 1:
-                # Map over the Dataset which contains only a single DataArray
-                return node.map(lambda da: func(da, *args, **kwargs))
+                # Apply fn to ds which contains a single da and rebuild the ds
+                return self._apply_to_single_dataarray_dataset(
+                    node, func, *args, **kwargs
+                )
             elif len(node) == 0:
                 pass
             else:

--- a/tests/core/accessors/test_datatree_accessors.py
+++ b/tests/core/accessors/test_datatree_accessors.py
@@ -1,0 +1,32 @@
+import numpy as np
+import xarray as xr
+
+import peaks  # noqa: F401
+
+
+def _make_single_scan_datatree():
+    da = xr.DataArray(
+        np.arange(16, dtype=float).reshape(4, 4),
+        dims=("eV", "theta_par"),
+        coords={"eV": np.linspace(-0.3, 0.3, 4), "theta_par": np.linspace(-1, 1, 4)},
+        name="data",
+    ).history.assign("seed history")
+    return xr.DataTree.from_dict({"scan": da.to_dataset()})
+
+
+def test_iterable_datatree_accessor_updates_history_for_bin_data():
+    result = _make_single_scan_datatree().bin_data(2)
+
+    history = result["scan"].ds["data"].history.get()
+
+    assert len(history) == 2
+    assert history[-1]["record"].startswith("Binned data using the bins:")
+
+
+def test_iterable_datatree_accessor_updates_history_for_mdc():
+    result = _make_single_scan_datatree().MDC(E=0, dE=0.1)
+
+    history = result["scan"].ds["data"].history.get()
+
+    assert len(history) == 2
+    assert history[-1]["record"] == "MDC(s) extracted, integration window: 0.1"

--- a/tests/core/accessors/test_datatree_accessors.py
+++ b/tests/core/accessors/test_datatree_accessors.py
@@ -1,10 +1,12 @@
 import numpy as np
+import pytest
 import xarray as xr
 
 import peaks  # noqa: F401
 
 
-def _make_single_scan_datatree():
+@pytest.fixture
+def single_scan_datatree():
     da = xr.DataArray(
         np.arange(16, dtype=float).reshape(4, 4),
         dims=("eV", "theta_par"),
@@ -14,19 +16,19 @@ def _make_single_scan_datatree():
     return xr.DataTree.from_dict({"scan": da.to_dataset()})
 
 
-def test_iterable_datatree_accessor_updates_history_for_bin_data():
-    result = _make_single_scan_datatree().bin_data(2)
+class TestIterableDataTreeAccessor:
+    def test_bin_data_updates_history(self, single_scan_datatree):
+        result = single_scan_datatree.bin_data(2)
 
-    history = result["scan"].ds["data"].history.get()
+        history = result["scan"].ds["data"].history.get()
 
-    assert len(history) == 2
-    assert history[-1]["record"].startswith("Binned data using the bins:")
+        assert len(history) == 2
+        assert history[-1]["record"].startswith("Binned data using the bins:")
 
+    def test_mdc_updates_history(self, single_scan_datatree):
+        result = single_scan_datatree.MDC(E=0, dE=0.1)
 
-def test_iterable_datatree_accessor_updates_history_for_mdc():
-    result = _make_single_scan_datatree().MDC(E=0, dE=0.1)
+        history = result["scan"].ds["data"].history.get()
 
-    history = result["scan"].ds["data"].history.get()
-
-    assert len(history) == 2
-    assert history[-1]["record"] == "MDC(s) extracted, integration window: 0.1"
+        assert len(history) == 2
+        assert history[-1]["record"] == "MDC(s) extracted, integration window: 0.1"


### PR DESCRIPTION
Bug fix for how accessor methods are applied when iterating over a hollow data tree, such that metadata (e.g. changed analysis_history) is correctly updated.

Closes #38 