### PR TITLE
Fix loc identification reading metadata in wrong format when loading zip files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.2]
+## [0.5.2.dev]
+
+### Fixed
+
+- Data loading bug for SES `zip` files where the loc identification handler reads metadata in the parsed pydantic-model format rather than the flat raw dictionary it requires ([PR#47](https://github.com/phrgab/peaks/pull/47))
 
 ## [0.5.1] - 2026-05-29
 

--- a/peaks/core/fileIO/loc_registry.py
+++ b/peaks/core/fileIO/loc_registry.py
@@ -136,8 +136,6 @@ class IdentifyLoc:
         metadata = BaseDataLoader.load_metadata(
             fname, loc="SES", return_as_dict=True, quiet=True
         )
-        print(f"keys are {sorted(metadata.keys())}")
-        print(f"local loc identifier is {metadata.get('local_location_identifier')}")
         location_identifier = metadata.get("local_location_identifier")
         if (
             "bloch" in location_identifier.lower()

--- a/peaks/core/fileIO/loc_registry.py
+++ b/peaks/core/fileIO/loc_registry.py
@@ -102,7 +102,9 @@ class IdentifyLoc:
             )
 
             # Extract metadata dictionary from file
-            metadata = BaseDataLoader.load_metadata(fname, loc="SES", quiet=True)
+            metadata = BaseDataLoader.load_metadata(
+                fname, loc="SES", return_as_dict=True, quiet=True
+            )
             location_identifier = metadata.get("local_location_identifier")
             if (
                 "bloch" in location_identifier.lower()
@@ -131,7 +133,11 @@ class IdentifyLoc:
         from peaks.core.fileIO.base_data_classes.base_data_class import BaseDataLoader
 
         # Extract metadata dictionary from file
-        metadata = BaseDataLoader.load_metadata(fname, loc="SES", quiet=True)
+        metadata = BaseDataLoader.load_metadata(
+            fname, loc="SES", return_as_dict=True, quiet=True
+        )
+        print(f"keys are {sorted(metadata.keys())}")
+        print(f"local loc identifier is {metadata.get('local_location_identifier')}")
         location_identifier = metadata.get("local_location_identifier")
         if (
             "bloch" in location_identifier.lower()


### PR DESCRIPTION
`IdentifyLoc._handler_zip` calls `load_metadata()` on `BaseDataLoader` to read the flat raw key `local_location_identifier` but it didn't pass `return_as_dict=True`, so it received parsed metadata models instead which don't have that key.

The call worked before by accident I reckon - the positional argument bug in `load_metadata` (fixed in `v0.5.1`, [see line 213 here](https://github.com/phrgab/peaks/pull/33/files#diff-0c55e1a2427acc8648665d3700ca8e03d83dbdbdc983bb4938cf04d088d98ea2)) somehow seemed to force `return_as_dict` to True.

Passing `return_as_dict=True` explicitly fixes the bug

Closes #46 