### PR TITLE
Migrating from pydantic v1 to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.2]
 
+### Added
+
+- Unit tests for `core/fileIO`: `data_saving` ([PR#48](https://github.com/phrgab/peaks/pull/48))
+
+### Changed
+
+- Pydantic v1 methods to their v2 equivalents ([PR#48](https://github.com/phrgab/peaks/pull/48))
+
 ## [0.5.1] - 2026-05-29
+
+:::{important}
+This version introduced a bug affecting the loading of SES-acquired zip files. Please install a later version if you work with this type of data.
+:::
 
 ### Added
 

--- a/peaks/core/fileIO/data_saving.py
+++ b/peaks/core/fileIO/data_saving.py
@@ -29,7 +29,7 @@ def _serialise_attrs(attrs):
     # Make data attributes serialisable
     for attr_name, attr in attrs.copy().items():
         try:  # Attrs should generally define json method to convert to/from json string
-            attrs[attr_name] = attr.json(by_alias=True)
+            attrs[attr_name] = attr.model_dump_json(by_alias=True)
             metadata_models[attr_name] = (
                 f"{attr.__class__.__module__}.{attr.__class__.__name__}"
             )

--- a/peaks/core/fileIO/loaders/netcdf.py
+++ b/peaks/core/fileIO/loaders/netcdf.py
@@ -109,10 +109,12 @@ class NetCDFLoader(BaseDataLoader):
                     ManipulatorMetadataModel = create_model(
                         "ManipulatorMetadataModel", **fields
                     )
-                    data.attrs[attr_name] = ManipulatorMetadataModel.parse_raw(attr)
+                    data.attrs[attr_name] = ManipulatorMetadataModel.model_validate_json(
+                        attr
+                    )
                 elif model:
                     model_class = cls._get_metadata_model(model)
-                    data.attrs[attr_name] = model_class.parse_raw(attr)
+                    data.attrs[attr_name] = model_class.model_validate_json(attr)
 
     @classmethod
     def _get_metadata_model(cls, class_path):

--- a/peaks/core/metadata/base_metadata_models.py
+++ b/peaks/core/metadata/base_metadata_models.py
@@ -16,7 +16,13 @@ class Quantity(pint.Quantity):
     @classmethod
     def __get_pydantic_core_schema__(cls, source_type, handler):
         # Use with_info_plain_validator_function to handle both value and info
-        return core_schema.with_info_plain_validator_function(cls.validate)
+        return core_schema.with_info_plain_validator_function(
+            cls.validate,
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                _quantity_encoder,
+                when_used="json",  # https://pydantic.dev/docs/validation/latest/concepts/json_schema#implementing-__get_pydantic_core_schema__
+            ),
+        )
 
     @classmethod
     def validate(cls, v, info):
@@ -68,9 +74,7 @@ def _quantity_encoder(quantity: pint.Quantity):
 class BaseMetadataModel(BaseModel):
     """Generalized model to store metadata, allowing serialising pint.Quantity objects."""
 
-    model_config = ConfigDict(
-        json_encoders={pint.Quantity: _quantity_encoder}, validate_assignment=True
-    )
+    model_config = ConfigDict(validate_assignment=True)
 
 
 class BaseScanMetadataModel(BaseMetadataModel):

--- a/peaks/core/metadata/base_metadata_models.py
+++ b/peaks/core/metadata/base_metadata_models.py
@@ -20,7 +20,7 @@ class Quantity(pint.Quantity):
             cls.validate,
             serialization=core_schema.plain_serializer_function_ser_schema(
                 _quantity_encoder,
-                when_used="json",  # https://pydantic.dev/docs/validation/latest/concepts/json_schema#implementing-__get_pydantic_core_schema__
+                when_used="json",
             ),
         )
 

--- a/peaks/core/metadata/history.py
+++ b/peaks/core/metadata/history.py
@@ -9,7 +9,7 @@ from typing import List, Union
 import pandas as pd
 import xarray as xr
 from IPython.display import display
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from peaks import __version__
 
@@ -21,11 +21,11 @@ class AnalysisHistoryRecord(BaseModel):
     peaks_version: str = Field(..., alias="peaks version")
     record: Union[str, dict]
     fn_name: str = Field(..., alias="function name")
-
-    class Config:
-        populate_by_name = (
+    model_config = ConfigDict(
+        populate_by_name=(
             True  # Allow aliases for both serialization and deserialization
         )
+    )
 
 
 class AnalysisHistoryRecordCollection(BaseModel):
@@ -194,7 +194,7 @@ class History:
         """Make a nice in-line display of the history metadata and return a timestamp string."""
         analysis_history = self._obj.attrs.get("_analysis_history")
         if analysis_history:
-            analysis_history = analysis_history.dict(by_alias=True)["records"]
+            analysis_history = analysis_history.model_dump(by_alias=True)["records"]
         df = pd.DataFrame(analysis_history)
         with pd.option_context(
             "display.max_colwidth", None, "display.colheader_justify", "left"
@@ -230,7 +230,7 @@ class History:
         record = (
             self._obj.attrs.get("_analysis_history")
             .records[index if index is not None else -1]
-            .dict(by_alias=True)
+            .model_dump(by_alias=True)
             .copy()
         )
         pprint(record)
@@ -286,7 +286,7 @@ class History:
         """
         return (
             self._obj.attrs.get("_analysis_history")
-            .dict(by_alias=True)
+            .model_dump(by_alias=True)
             .copy()["records"][index if index is not None else slice(None)]
         )
 
@@ -310,7 +310,7 @@ class History:
             # Get the history metadata as a JSON-formatted string
             disp_k.history.json()
         """
-        return self._obj.attrs.get("_analysis_history").json(by_alias=True)
+        return self._obj.attrs.get("_analysis_history").model_dump_json(by_alias=True)
 
     def save(self, fname):
         """Save the history metadata as a JSON-formatted string.

--- a/peaks/core/metadata/metadata_methods.py
+++ b/peaks/core/metadata/metadata_methods.py
@@ -103,12 +103,14 @@ def display_metadata(da_or_model, palette=None, mode="HTML"):
     # Display the model with colored keys
     try:
         metadata = {
-            key.lstrip("_"): value.dict()
+            key.lstrip("_"): value.model_dump()
             for key, value in da_or_model.attrs.items()
             if key.startswith("_") and key not in ["_analysis_history"]
         }
     except AttributeError:
-        metadata = da_or_model if isinstance(da_or_model, dict) else da_or_model.dict()
+        metadata = (
+            da_or_model if isinstance(da_or_model, dict) else da_or_model.model_dump()
+        )
     if mode.upper() == "ANSI":
         return "\n".join(display_coloured_dict_ansi(metadata))
     elif mode.upper() == "HTML":
@@ -123,12 +125,12 @@ def compare_metadata(da_or_model1, da_or_model2):
     def get_metadata(da_or_model):
         try:
             metadata = {
-                key.lstrip("_"): value.dict()
+                key.lstrip("_"): value.model_dump()
                 for key, value in da_or_model.attrs.items()
                 if key.startswith("_") and key not in ["_analysis_history"]
             }
         except AttributeError:
-            metadata = da_or_model.dict()
+            metadata = da_or_model.model_dump()
         return metadata
 
     metadata1 = get_metadata(da_or_model1)
@@ -418,7 +420,7 @@ class Metadata:
             A dictionary of the normal emission angles and also scan name.
         """
         # Get the axis names in da
-        axes = list(da._manipulator.dict().keys())
+        axes = list(da._manipulator.model_dump().keys())
         # Get any set reference data in da
         current_reference_data = {
             axis: {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,5 +109,8 @@ fixable = ["I"]
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
 
+[tool.pytest]
+filterwarnings = ["ignore::pint.UnitStrippedWarning"]
+
 [tool.flit.module]
 name = "peaks"

--- a/tests/core/accessors/test_datatree_accessors.py
+++ b/tests/core/accessors/test_datatree_accessors.py
@@ -16,6 +16,25 @@ def single_scan_datatree():
     return xr.DataTree.from_dict({"scan": da.to_dataset()})
 
 
+@pytest.fixture
+def multi_scan_datatree():
+    def make_a_da(seed):
+        return xr.DataArray(
+            np.arange(16, dtype=float).reshape(4, 4),
+            dims=("eV", "theta_par"),
+            coords={"eV": np.linspace(-0.3, 0.3, 4), "theta_par": np.linspace(-1, 1, 4)},
+            name="data",
+        ).history.assign(seed)
+
+    return xr.DataTree.from_dict(
+        {
+            "scan1": make_a_da("seed history 1").to_dataset(),
+            "scan2": make_a_da("seed history 2").to_dataset(),
+            "scan3": make_a_da("seed history 3").to_dataset(),
+        }
+    )
+
+
 class TestIterableDataTreeAccessor:
     def test_bin_data_updates_history(self, single_scan_datatree):
         result = single_scan_datatree.bin_data(2)
@@ -24,6 +43,14 @@ class TestIterableDataTreeAccessor:
 
         assert len(history) == 2
         assert history[-1]["record"].startswith("Binned data using the bins:")
+
+    def test_bin_data_updates_history_on_all_leaves(self, multi_scan_datatree):
+        result = multi_scan_datatree.bin_data(2)
+
+        for node in ("scan1", "scan2"):
+            history = result[node].ds["data"].history.get()
+            assert len(history) == 2
+            assert history[-1]["record"].startswith("Binned data using the bins:")
 
     def test_mdc_updates_history(self, single_scan_datatree):
         result = single_scan_datatree.MDC(E=0, dE=0.1)

--- a/tests/core/fileIO/test_data_saving.py
+++ b/tests/core/fileIO/test_data_saving.py
@@ -1,0 +1,21 @@
+import pytest
+
+from peaks.core.fileIO.data_loading import load
+from peaks.core.metadata.metadata_methods import display_metadata
+from peaks.core.utils.sample_data import ExampleData
+
+
+@pytest.fixture(scope="session")
+def disp():
+    return ExampleData.dispersion()
+
+
+class TestSave:
+    def test_save_load_roundtrip_preserves_metadata(self, disp, tmp_path):
+        fpath = tmp_path / "peaks_saved_disp.nc"
+        original_data = disp.copy(deep=True)
+        original_data.save(str(fpath))
+        result = load(str(fpath))
+
+        assert set(result.metadata.keys()) == set(original_data.metadata.keys())
+        assert display_metadata(result) == display_metadata(original_data)

--- a/tests/core/fileIO/test_data_saving.py
+++ b/tests/core/fileIO/test_data_saving.py
@@ -19,3 +19,7 @@ class TestSave:
 
         assert set(result.metadata.keys()) == set(original_data.metadata.keys())
         assert display_metadata(result) == display_metadata(original_data)
+
+    def test_save_with_wrong_extension_raises(self, disp, tmp_path):
+        with pytest.raises(ValueError, match="File path must have a .nc extension"):
+            disp.save(str(tmp_path / "disp.zarr"))


### PR DESCRIPTION
As per the title, changes mostly on the methods that were renamed based on [the migration guide](https://pydantic.dev/docs/validation/latest/get-started/migration/#changes-to-pydanticbasemodel).

Also added a couple of unit tests to check the metadata models still work fine after a save-load roundtrip.