### PR TITLE
Fix windows-specific bugs that pop up in tutorial notebooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Data loading bug for SES `zip` files where the loc identification handler reads metadata in the parsed pydantic-model format rather than the flat raw dictionary it requires ([PR#47](https://github.com/phrgab/peaks/pull/47))
 - Error on Windows when clearing up lazily loaded sample data ([PR#50](https://github.com/phrgab/peaks/pull/50))
 - Cross-platform filename parsing in loader ([PR#50](https://github.com/phrgab/peaks/pull/50))
-- Windows `PermissionError` when loading example CIF structure
+- Windows `PermissionError` when loading example CIF structure ([PR#50](https://github.com/phrgab/peaks/pull/50))
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Data loading bug for SES `zip` files where the loc identification handler reads metadata in the parsed pydantic-model format rather than the flat raw dictionary it requires ([PR#47](https://github.com/phrgab/peaks/pull/47))
 - Error on Windows when clearing up lazily loaded sample data ([PR#50](https://github.com/phrgab/peaks/pull/50))
-- Cross-platform filename parsing in loader
+- Cross-platform filename parsing in loader ([PR#50](https://github.com/phrgab/peaks/pull/50))
+- Windows `PermissionError` when loading example CIF structure
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Data loading bug for SES `zip` files where the loc identification handler reads metadata in the parsed pydantic-model format rather than the flat raw dictionary it requires ([PR#47](https://github.com/phrgab/peaks/pull/47))
+- Error on Windows when clearing up lazily loaded sample data ([PR#50](https://github.com/phrgab/peaks/pull/50))
+- Cross-platform filename parsing in loader
 
 ### Added
 

--- a/peaks/core/fileIO/base_data_classes/base_data_class.py
+++ b/peaks/core/fileIO/base_data_classes/base_data_class.py
@@ -329,7 +329,11 @@ class BaseDataLoader:
         data = cls._load_data(fpath, lazy, **kwargs)
         da = cls._make_dataarray(data)  # Convert to DataArray
         # Add a name to the DataArray
-        da.name = fpath.split("/")[-1].split(".")[0]
+        da.name = os.path.splitext(os.path.basename(fpath))[0]
+        print(
+            f"Get the final component: os.path.basename(fpath) is {os.path.basename(fpath)}"
+        )
+        print(f"Chuck the extension: da.name is {da.name}")
         parsed_metadata = cls.load_metadata(
             fpath,
             loc=cls._loc_name,
@@ -390,7 +394,7 @@ class BaseDataLoader:
         """Apply general metadata to the DataArray - implemented irrespective of the loader."""
         fpath = metadata_dict.get("fpath")
         general_scan_metadata = BaseScanMetadataModel(
-            name=fpath.split("/")[-1].split(".")[0],
+            name=os.path.splitext(os.path.basename(fpath))[0],
             filepath=fpath,
             loc=cls._loc_name,
             timestamp=metadata_dict.get("timestamp"),

--- a/peaks/core/fileIO/base_data_classes/base_data_class.py
+++ b/peaks/core/fileIO/base_data_classes/base_data_class.py
@@ -330,10 +330,6 @@ class BaseDataLoader:
         da = cls._make_dataarray(data)  # Convert to DataArray
         # Add a name to the DataArray
         da.name = os.path.splitext(os.path.basename(fpath))[0]
-        print(
-            f"Get the final component: os.path.basename(fpath) is {os.path.basename(fpath)}"
-        )
-        print(f"Chuck the extension: da.name is {da.name}")
         parsed_metadata = cls.load_metadata(
             fpath,
             loc=cls._loc_name,

--- a/peaks/core/utils/sample_data.py
+++ b/peaks/core/utils/sample_data.py
@@ -354,7 +354,7 @@ class ExampleData:
         with the database sever as the fallback (used in CI)."""
         data = cls._cache.get("structure")
         if data is None:
-            local_mirror = os.getenv("LOCAL_MIRROR_PATHo")
+            local_mirror = os.getenv("LOCAL_MIRROR_PATH")
             if local_mirror:
                 local_path = os.path.join(local_mirror, "4515175.cif")
                 if os.path.exists(local_path):
@@ -367,11 +367,9 @@ class ExampleData:
                     try:
                         tmp.write(response.text)
                         tmp.close()
-                        print("closed the tmp file")
                         data = load(tmp.name)
                     finally:
                         os.unlink(tmp.name)
-                        print("deleted the tmp file")
                 else:
                     raise ValueError(
                         f"Failed to download CIF. HTTP status code: {response.status_code}"

--- a/peaks/core/utils/sample_data.py
+++ b/peaks/core/utils/sample_data.py
@@ -178,7 +178,6 @@ class ZenodoDownloader:
                 )
                 return
 
-            # self._tempdir_context.cleanup()
             self._tempdir_context = None
             self.downloaded_files = {}
             analysis_warning(

--- a/peaks/core/utils/sample_data.py
+++ b/peaks/core/utils/sample_data.py
@@ -153,7 +153,32 @@ class ZenodoDownloader:
         If ``True``, suppress the success notice. Defaults to ``False``.
         """
         if self._tempdir_context is not None:
-            self._tempdir_context.cleanup()
+            import gc
+
+            import h5py
+
+            tmpdir = self._tempdir_context.name
+            for obj in gc.get_objects():  # handle win error 32 when data can't be deleted because of open file handles
+                try:
+                    if isinstance(obj, h5py.File) and obj.id.valid:
+                        if obj.filename.startswith(tmpdir):
+                            obj.close()
+                except Exception:
+                    continue
+            gc.collect()
+
+            try:
+                self._tempdir_context.cleanup()
+            except (PermissionError, OSError) as e:
+                analysis_warning(
+                    f"Some temporary files could not be deleted: {e}",
+                    f"Clean them up manually at <code>{tmpdir}</code>.",
+                    title="Cleanup incomplete",
+                    warn_type="warning",
+                )
+                return
+
+            # self._tempdir_context.cleanup()
             self._tempdir_context = None
             self.downloaded_files = {}
             analysis_warning(

--- a/peaks/core/utils/sample_data.py
+++ b/peaks/core/utils/sample_data.py
@@ -354,7 +354,7 @@ class ExampleData:
         with the database sever as the fallback (used in CI)."""
         data = cls._cache.get("structure")
         if data is None:
-            local_mirror = os.getenv("LOCAL_MIRROR_PATH")
+            local_mirror = os.getenv("LOCAL_MIRROR_PATHo")
             if local_mirror:
                 local_path = os.path.join(local_mirror, "4515175.cif")
                 if os.path.exists(local_path):
@@ -363,12 +363,15 @@ class ExampleData:
                 url = "https://qiserver.ugr.es/cod/4515175.cif"
                 response = requests.get(url)
                 if response.status_code == 200:
-                    with tempfile.NamedTemporaryFile(
-                        "w+", suffix=".cif", delete=True
-                    ) as tmp:
+                    tmp = tempfile.NamedTemporaryFile("w+", suffix=".cif", delete=False)
+                    try:
                         tmp.write(response.text)
-                        tmp.flush()
+                        tmp.close()
+                        print("closed the tmp file")
                         data = load(tmp.name)
+                    finally:
+                        os.unlink(tmp.name)
+                        print("deleted the tmp file")
                 else:
                     raise ValueError(
                         f"Failed to download CIF. HTTP status code: {response.status_code}"


### PR DESCRIPTION
A few fixes to make it a bit more OS-agnostic.

Originally raised for bug 1 but I noticed a few more windows quirks whilst going through other tutorials so fixing them in one go.

## Bug 1 (tutorial 1)

Running the `sample_data.cleanup()` cell on a windows computer returns the error below

```python
---------------------------------------------------------------------------
PermissionError                           Traceback (most recent call last)
File ~\AppData\Local\miniconda3\envs\temp-pks\Lib\shutil.py:625, in _rmtree_unsafe(path, onexc)
    624 try:
--> 625     os.unlink(fullname)
    626 except FileNotFoundError:

PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\mbe-lab\\AppData\\Local\\Temp\\tmpwwok7ywj\\i05-59818.nxs'

During handling of the above exception, another exception occurred:

PermissionError                           Traceback (most recent call last)
Cell In[84], line 1
----> 1 sample_data.cleanup()

File ~\Documents\temp-pks\peaks\peaks\core\utils\sample_data.py:156, in ZenodoDownloader.cleanup(self, quiet)
    148 """Delete the temporary directory and all downloaded files and reset download state.
    149 
    150 Parameters
   (...)    153 If ``True``, suppress the success notice. Defaults to ``False``.
    154 """
    155 if self._tempdir_context is not None:
--> 156     self._tempdir_context.cleanup()
    157     self._tempdir_context = None
    158     self.downloaded_files = {}

File ~\AppData\Local\miniconda3\envs\temp-pks\Lib\tempfile.py:955, in TemporaryDirectory.cleanup(self)
    953 def cleanup(self):
    954     if self._finalizer.detach() or _os.path.exists(self.name):
--> 955         self._rmtree(self.name, ignore_errors=self._ignore_cleanup_errors)

File ~\AppData\Local\miniconda3\envs\temp-pks\Lib\tempfile.py:935, in TemporaryDirectory._rmtree(cls, name, ignore_errors, repeated)
    932         if not ignore_errors:
    933             raise
--> 935 _shutil.rmtree(name, onexc=onexc)

File ~\AppData\Local\miniconda3\envs\temp-pks\Lib\shutil.py:790, in rmtree(path, ignore_errors, onerror, onexc, dir_fd)
    788     # can't continue even if onexc hook returns
    789     return
--> 790 return _rmtree_unsafe(path, onexc)

File ~\AppData\Local\miniconda3\envs\temp-pks\Lib\shutil.py:629, in _rmtree_unsafe(path, onexc)
    627             continue
    628         except OSError as err:
--> 629             onexc(os.unlink, fullname, err)
    630 try:
    631     os.rmdir(path)

File ~\AppData\Local\miniconda3\envs\temp-pks\Lib\tempfile.py:910, in TemporaryDirectory._rmtree.<locals>.onexc(func, path, exc)
    907 _resetperms(path)
    909 try:
--> 910     _os.unlink(path)
    911 except IsADirectoryError:
    912     cls._rmtree(path, ignore_errors=ignore_errors)

PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\[REDACTED]\\AppData\\Local\\Temp\\tmpwwok7ywj\\i05-59818.nxs'
```

---

## Bug 2 (tutorial 4)

Gibberish prepended to the filename when adding an xr da to an xr dt

```python
<xarray.DataTree>
Group: /
├── Group: /C__Users_[REDACTED]_AppData_Local_Temp_tmp82y72sha_Gold
│       Dimensions:    (theta_par: 410, eV: 101)
```

Root cause is that windows uses backslashes in file paths whereas UNIX OSes use forward slashes, and old code only handles the latter. So the full path was preserved there when parsing the filename

---

## Bug 3 (tutorial 5)

Couldn't open the temporary CIF file. [This has been documented](https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile). There's a `delete_on_close` parameter added in 3.12 dealing with this issue, which we can use when dropping support for 3.11.

```python
---------------------------------------------------------------------------
PermissionError                           Traceback (most recent call last)
Cell In[3], line 1
----> 1 atoms = ExampleData.structure()

File ~\Documents\temp-pks\peaks\peaks\core\utils\sample_data.py:371, in ExampleData.structure(cls)
    369         tmp.write(response.text)
    370         tmp.flush()
--> 371         data = load(tmp.name)
    372 else:
    373     raise ValueError(
    374         f"Failed to download CIF. HTTP status code: {response.status_code}"
    375     )

File ~\Documents\temp-pks\peaks\peaks\core\fileIO\data_loading.py:172, in load(fpath, lazy, loc, metadata, parallel, names, quiet, **kwargs)
    170 # If a full file path provided, always load only this
    171 if isinstance(fpath, str) and os.path.exists(fpath) and "." in fpath:
--> 172     return _load_data(fpath, **load_opts)
    174 # Set placeholder file path and extension
    175 base_path = [None]

File ~\Documents\temp-pks\peaks\peaks\core\fileIO\data_loading.py:300, in _load_data(fpath, lazy, loc, metadata, parallel, names, quiet, **kwargs)
    293 # If not, load files sequentially
    294 else:
    295     for single_fpath in tqdm(
    296         fpath,
    297         desc="Loading data",
    298         disable=len(fpath) == 1,
    299     ):
--> 300         loaded_data.append(BaseDataLoader.load(fpath=single_fpath, **load_opts))
    302 # Check if any of the loaded data have been lazily evaluated. If so, inform the user
    303 for data in loaded_data:

File ~\Documents\temp-pks\peaks\peaks\core\fileIO\base_data_classes\base_data_class.py:152, in BaseDataLoader.load(cls, fpath, lazy, loc, metadata, quiet, **kwargs)
    150 # Trigger the loader for the correct loc
    151 loader_class = cls.get_loader(loc)
--> 152 return loader_class._load(fpath, lazy, metadata, quiet, **kwargs)

File ~\Documents\temp-pks\peaks\peaks\core\fileIO\loaders\cif.py:22, in BaseStructureLoader._load(cls, fpath, lazy, metadata, quiet, **kwargs)
     16 except ImportError as e:
     17     raise ImportError(
     18         "The 'ase' module is required to use this module. Please install it using \
     19 'pip install ase'."
     20     ) from e
---> 22 return ase.io.read(fpath)

File ~\AppData\Local\miniconda3\envs\temp-pks\Lib\site-packages\ase\io\formats.py:780, in read(filename, index, format, parallel, do_not_split_by_at_sign, **kwargs)
    778 if index is None:
    779     index = -1
--> 780 format = format or filetype(filename, read=isinstance(filename, str))
    782 io = get_ioformat(format)
    783 if isinstance(index, (slice, str)):

File ~\AppData\Local\miniconda3\envs\temp-pks\Lib\site-packages\ase\io\formats.py:955, in filetype(filename, read, guess)
    952     return ext
    954 if orig_filename == filename:
--> 955     fd = open_with_compression(filename, 'rb')
    956 else:
    957     fd = orig_filename  # type: ignore[assignment]

File ~\AppData\Local\miniconda3\envs\temp-pks\Lib\site-packages\ase\io\formats.py:584, in open_with_compression(filename, mode)
    581     return lzma.open(filename, mode)
    582 else:
    583     # Either None or unknown string
--> 584     return open(filename, mode)

PermissionError: [Errno 13] Permission denied: 'C:\\Users\\[REDACTED]\\AppData\\Local\\Temp\\tmp8rk7hf7j.cif'
```
