### PR TITLE
Update i05 data loader following analyser upgrade and minor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.2.dev]
 
+### Fixed
+
+- 'Pretty'-formatted normal emission values copied from the display panel that can't be parsed ([PR#53](https://github.com/phrgab/peaks/pull/53))
+- `plot_fit` doesn't render multiple fits and sliders during the docs build ([PR#53](https://github.com/phrgab/peaks/pull/53))
+
 ### Changed
 
-- Diamond I05 data loader, following the analyser upgrade ([PR#XX](https://github.com/phrgab/peaks/pull/XX))
+- Diamond I05 data loader, following the analyser upgrade in 2026 ([PR#53](https://github.com/phrgab/peaks/pull/53))
 
 ## [0.5.1] - 2026-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.2]
+## [0.5.2.dev]
+
+### Changed
+
+- Diamond I05 data loader, following the analyser upgrade ([PR#XX](https://github.com/phrgab/peaks/pull/XX))
 
 ## [0.5.1] - 2026-05-29
 

--- a/peaks/core/GUI/disp_panels/disp_2d.py
+++ b/peaks/core/GUI/disp_panels/disp_2d.py
@@ -916,7 +916,7 @@ class _Disp2D(QtWidgets.QMainWindow):
         # Current norm values
         norm_values = self._get_norm_values()
         norm_values_to_return = {
-            k: str(v) if isinstance(v, pint.Quantity) else v
+            k: f"{v:~D}" if isinstance(v, pint.Quantity) else v
             for k, v in norm_values.items()
         }
         pyperclip.copy(f".metadata.set_normal_emission({norm_values_to_return})")

--- a/peaks/core/GUI/disp_panels/disp_3d.py
+++ b/peaks/core/GUI/disp_panels/disp_3d.py
@@ -922,7 +922,7 @@ class _Disp3D(QtWidgets.QMainWindow):
         # Current norm values
         norm_values = self._get_norm_values()
         norm_values_to_return = {
-            k: str(v) if isinstance(v, pint.Quantity) else v
+            k: f"{v:~D}" if isinstance(v, pint.Quantity) else v
             for k, v in norm_values.items()
         }
         pyperclip.copy(f".metadata.set_normal_emission({norm_values_to_return})")

--- a/peaks/core/display/plotting.py
+++ b/peaks/core/display/plotting.py
@@ -1,5 +1,7 @@
 """Static in-line plotting functions."""
 
+import os
+
 import matplotlib.pyplot as plt
 import numpy as np
 import panel as pn
@@ -8,6 +10,7 @@ import xarray as xr
 from cycler import cycler
 from IPython.display import display
 from matplotlib import cm, colors
+from matplotlib.figure import Figure
 from numpy.fft import fft
 
 from peaks.core.utils.misc import analysis_warning
@@ -527,7 +530,7 @@ def plot_fit(fit_results_ds, show_components=True, figsize=None, **kwargs):
     """
 
     def _plot_single_fit(fit_results, show_components, figsize, **kwargs):
-        fig = plt.figure(figsize=figsize)
+        fig = Figure(figsize=figsize)
         for dim in fit_results.dims:
             if dim in kwargs:
                 fit_results = fit_results.isel({dim: kwargs.pop(dim)})
@@ -537,7 +540,10 @@ def plot_fit(fit_results_ds, show_components=True, figsize=None, **kwargs):
         fit_model = fit_results["fit_model"].compute().item()
         fit_model.plot(fig=fig, **kwargs)
         if show_components and len(fit_model.components) > 1:
-            ax = plt.gca()
+            ax = next(
+                (a for a in fig.axes if "residual" not in a.get_ylabel().lower()),
+                fig.axes[-1],
+            )
             components = fit_model.eval_components()
             for component_name, component_data in components.items():
                 if component_name != "_gauss_conv":
@@ -548,7 +554,6 @@ def plot_fit(fit_results_ds, show_components=True, figsize=None, **kwargs):
                         linestyle="--",
                     )
             ax.legend()
-        plt.close(fig)
         return fig
 
     # Check the data array contains fit results
@@ -585,8 +590,15 @@ def plot_fit(fit_results_ds, show_components=True, figsize=None, **kwargs):
 
         # Display the sliders and the plot in the notebook
         dashboard = pn.Column(
-            pn.Row(*sliders.values()), pn.pane.Matplotlib(interactive_plot)
+            pn.Row(*sliders.values()),
+            pn.pane.Matplotlib(
+                interactive_plot, sizing_mode="stretch_width", fixed_aspect=True
+            ),
+            sizing_mode="stretch_width",
         )
+
+        if os.getenv("FORCE_NB_EXECUTION") == "1":
+            return dashboard.embed(max_states=1000)  # for documentation purposes
 
         dashboard.servable()
         return dashboard

--- a/peaks/core/display/plotting.py
+++ b/peaks/core/display/plotting.py
@@ -591,10 +591,8 @@ def plot_fit(fit_results_ds, show_components=True, figsize=None, **kwargs):
         # Display the sliders and the plot in the notebook
         dashboard = pn.Column(
             pn.Row(*sliders.values()),
-            pn.pane.Matplotlib(
-                interactive_plot, sizing_mode="stretch_width", fixed_aspect=True
-            ),
-            sizing_mode="stretch_width",
+            pn.pane.Matplotlib(interactive_plot),
+            sizing_mode="scale_width",
         )
 
         if os.getenv("FORCE_NB_EXECUTION") == "1":

--- a/peaks/core/display/plotting.py
+++ b/peaks/core/display/plotting.py
@@ -1,6 +1,7 @@
 """Static in-line plotting functions."""
 
 import os
+import textwrap
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -516,7 +517,9 @@ def plot_3d_stack(
     plt.show()
 
 
-def plot_fit(fit_results_ds, show_components=True, figsize=None, **kwargs):
+def plot_fit(
+    fit_results_ds, show_components=True, figsize=None, pane_height=450, **kwargs
+):
     """Plot fit results from a fit stored in an xarray.Dataset.
 
     Parameters
@@ -526,6 +529,11 @@ def plot_fit(fit_results_ds, show_components=True, figsize=None, **kwargs):
     show_components : bool, optional
         If True (default) overlay individual model components as dashed lines.
     figsize : tuple of float, optional
+        Figure size ``(width, height)`` in inches, passed to the underlying
+        matplotlib figure. If None, matplotlib's default is used.
+    pane_height : int, optional
+        Height in pixels of the matplotlib pane in the interactive dashboard
+        (multi-dimensional fits only). Defaults to 450.
     **kwargs : optional
     """
 
@@ -539,6 +547,10 @@ def plot_fit(fit_results_ds, show_components=True, figsize=None, **kwargs):
 
         fit_model = fit_results["fit_model"].compute().item()
         fit_model.plot(fig=fig, **kwargs)
+        for a in fig.axes:
+            title = a.get_title()
+            if title:
+                a.set_title("\n".join(textwrap.wrap(title, width=65)))
         if show_components and len(fit_model.components) > 1:
             ax = next(
                 (a for a in fig.axes if "residual" not in a.get_ylabel().lower()),
@@ -591,8 +603,13 @@ def plot_fit(fit_results_ds, show_components=True, figsize=None, **kwargs):
         # Display the sliders and the plot in the notebook
         dashboard = pn.Column(
             pn.Row(*sliders.values()),
-            pn.pane.Matplotlib(interactive_plot),
-            sizing_mode="scale_width",
+            pn.pane.Matplotlib(
+                interactive_plot,
+                tight=True,
+                height=pane_height,
+                format="svg",
+                sizing_mode="stretch_width",
+            ),
         )
 
         if os.getenv("FORCE_NB_EXECUTION") == "1":

--- a/peaks/core/fileIO/loaders/diamond.py
+++ b/peaks/core/fileIO/loaders/diamond.py
@@ -506,8 +506,7 @@ class I05NanoARPESLoader(I05ARPESLoader, BaseOpticsDataLoader):
     }
 
     _analyser_sign_conventions = {
-        "theta_par": -1,
-        "deflector_parallel": -1,  # consistent with theta_par
+        # overriden when loading data to take account of analyser upgrade see below
     }
 
     _desired_dim_order = [
@@ -530,8 +529,7 @@ class I05NanoARPESLoader(I05ARPESLoader, BaseOpticsDataLoader):
     ]
 
     _analyser_name_conventions = {
-        "deflector_perp": "ThetaY",
-        "deflector_parallel": "ThetaX",
+        # deflector conventions overridden when loading data to take account of analyser upgrade see below
         "eV": ["energies", "kinetic_energy_center"],
         "theta_par": "angles",
         "hv": ["energy", "value"],
@@ -558,14 +556,61 @@ class I05NanoARPESLoader(I05ARPESLoader, BaseOpticsDataLoader):
         "manipulator_x2": "entry1/instrument/manipulator/smy",
         "manipulator_x3": "entry1/instrument/manipulator/smz",
         "manipulator_defocus": "entry1/instrument/manipulator/smdefocus",
-        "analyser_model": "FIXED_VALUE:Scienta DA30",
-        "analyser_slit_width": [
-            "entry1/instrument/analyser/entrance_slit_size",
-            "entry1/instrument/analyser_total/entrance_slit_size",
+        "analyser_model": lambda f: (
+            (
+                "FIXED_VALUE:MBS A1"
+                if parse(
+                    (
+                        (f["entry1/start_time"][()]).decode()
+                        if isinstance(f["entry1/start_time"][()], bytes)
+                        else f["entry1/start_time"][()]
+                    )
+                )
+                > datetime(2026, 4, 1, tzinfo=timezone.utc)
+                else "FIXED_VALUE:Scienta DA30"
+            )
+            if "entry1/start_time" in f
+            else None
+        ),
+        "analyser_slit_width": [  # If the slit size is 0, assume it's not set and return None, otherwise return the value.
+            lambda f: (
+                None
+                if (
+                    v := BaseHDF5DataLoader._extract_hdf5_value(
+                        f, "entry1/instrument/analyser/entrance_slit_size"
+                    )
+                )
+                == 0
+                else v
+            ),
+            lambda f: (
+                None
+                if (
+                    v := BaseHDF5DataLoader._extract_hdf5_value(
+                        f, "entry1/instrument/analyser_total/entrance_slit_size"
+                    )
+                )
+                == 0
+                else v
+            ),
         ],
         "analyser_slit_width_identifier": [
-            "entry1/instrument/analyser/entrance_slit_setting",
-            "entry1/instrument/analyser_total/entrance_slit_setting",
+            lambda f: (
+                None  # If the slit size is 0 which is physcially impossible, assume it's not set and return None
+                if BaseHDF5DataLoader._extract_hdf5_value(
+                    f, "entry1/instrument/analyser/entrance_slit_size"
+                )
+                == 0
+                else "entry1/instrument/analyser/entrance_slit_setting"  # otherwise return it
+            ),
+            lambda f: (
+                None
+                if BaseHDF5DataLoader._extract_hdf5_value(
+                    f, "entry1/instrument/analyser_total/entrance_slit_size"
+                )
+                == 0
+                else "entry1/instrument/analyser_total/entrance_slit_setting"
+            ),
         ],
         "analyser_eV": [
             "entry1/instrument/analyser/energies",
@@ -619,8 +664,38 @@ class I05NanoARPESLoader(I05ARPESLoader, BaseOpticsDataLoader):
             "entry1/instrument/analyser_total/acquisition_mode",
         ],
         "analyser_eV_type": "FIXED_VALUE:kinetic",
-        "analyser_deflector_parallel": None,
-        "analyser_deflector_perp": None,
+        "analyser_deflector_parallel": lambda f: (
+            (
+                "entry1/instrument/analyser/deflector_y"
+                if parse(
+                    (
+                        (f["entry1/start_time"][()]).decode()
+                        if isinstance(f["entry1/start_time"][()], bytes)
+                        else f["entry1/start_time"][()]
+                    )
+                )
+                > datetime(2026, 4, 1, tzinfo=timezone.utc)
+                else None
+            )
+            if "entry1/start_time" in f
+            else None
+        ),
+        "analyser_deflector_perp": lambda f: (
+            (
+                "entry1/instrument/analyser/deflector_x"
+                if parse(
+                    (
+                        (f["entry1/start_time"][()]).decode()
+                        if isinstance(f["entry1/start_time"][()], bytes)
+                        else f["entry1/start_time"][()]
+                    )
+                )
+                > datetime(2026, 4, 1, tzinfo=timezone.utc)
+                else None
+            )
+            if "entry1/start_time" in f
+            else None
+        ),
         "analyser_polar": [
             "entry1/instrument/analyser/analyser_polar_angle",
             "entry1/instrument/analyser_total/analyser_polar_angle",
@@ -666,6 +741,36 @@ class I05NanoARPESLoader(I05ARPESLoader, BaseOpticsDataLoader):
         if fpath.split(".")[-1] == "zip":
             # Load the data using the SES loader for .zip files
             return cls.load(fpath, loc="SES", lazy=lazy, metadata=metadata)
+
+        # Choose analyser sign and name conventions for deflector based on acquisition date i.e. the analyser used at the time
+        with h5py.File(fpath, "r") as f:
+            if "entry1/start_time" in f:
+                _raw_start_time = f["entry1/start_time"][()]
+                _raw_start_time = (
+                    _raw_start_time.decode()
+                    if isinstance(_raw_start_time, bytes)
+                    else str(_raw_start_time)
+                )
+                _after_analyser_upgrade = parse(_raw_start_time) > datetime(
+                    2026, 4, 1, tzinfo=timezone.utc
+                )
+            else:
+                _after_analyser_upgrade = False
+        cls._analyser_sign_conventions["theta_par"] = (
+            1 if _after_analyser_upgrade else -1
+        )
+        cls._analyser_sign_conventions["deflector_parallel"] = (
+            1 if _after_analyser_upgrade else -1
+        )
+        cls._analyser_sign_conventions["deflector_perp"] = (
+            -1 if _after_analyser_upgrade else 1
+        )
+        cls._analyser_name_conventions["deflector_perp"] = (
+            "deflector_x" if _after_analyser_upgrade else "ThetaY"
+        )
+        cls._analyser_name_conventions["deflector_parallel"] = (
+            "deflector_y" if _after_analyser_upgrade else "ThetaX"
+        )
 
         # Load the data
         data = super()._load(fpath, lazy, metadata, quiet, **kwargs)

--- a/peaks/core/fileIO/loaders/diamond.py
+++ b/peaks/core/fileIO/loaders/diamond.py
@@ -193,8 +193,8 @@ class I05ARPESLoader(DiamondNXSLoader, BaseARPESDataLoader):
     }
 
     _analyser_name_conventions = {
-        "deflector_perp": "deflector_x",
-        "deflector_parallel": "deflector_y",
+        "deflector_perp": "deflector_x",  # These two don't exist for R4000 but fine for now
+        "deflector_parallel": "detector_y",  # Should handle them properly when we do the refactor
         "eV": ["energies", "kinetic_energy_center"],
         "theta_par": "angles",
         "hv": ["energy", "value"],
@@ -225,8 +225,36 @@ class I05ARPESLoader(DiamondNXSLoader, BaseARPESDataLoader):
             if "entry1/start_time" in f
             else None
         ),
-        "analyser_slit_width": "entry1/instrument/analyser/entrance_slit_size",
-        "analyser_slit_width_identifier": "entry1/instrument/analyser_total/entrance_slit_setting",
+        # "analyser_slit_width": "entry1/instrument/analyser/entrance_slit_size",
+        "analyser_slit_width": lambda f: (  # If the slit size is 0, assume it's not set and return None, otherwise return the value.
+            None
+            if (
+                v := BaseHDF5DataLoader._extract_hdf5_value(
+                    f, "entry1/instrument/analyser/entrance_slit_size"
+                )
+            )
+            == 0
+            else v
+        ),
+        # "analyser_slit_width_identifier": "entry1/instrument/analyser_total/entrance_slit_setting",
+        "analyser_slit_width_identifier": [
+            lambda f: (
+                None  # If the slit size is 0 which is physcially impossible, assume it's not set and return None
+                if BaseHDF5DataLoader._extract_hdf5_value(
+                    f, "entry1/instrument/analyser/entrance_slit_size"
+                )
+                == 0
+                else "entry1/instrument/analyser/entrance_slit_setting"  # otherwise return it
+            ),
+            lambda f: (
+                None
+                if BaseHDF5DataLoader._extract_hdf5_value(
+                    f, "entry1/instrument/analyser_total/entrance_slit_size"
+                )
+                == 0
+                else "entry1/instrument/analyser_total/entrance_slit_setting"
+            ),
+        ],
         "analyser_eV": "entry1/instrument/analyser/energies",
         "analyser_step_size": lambda f: (
             np.ptp(f["entry1/instrument/analyser/energies"])
@@ -244,8 +272,37 @@ class I05ARPESLoader(DiamondNXSLoader, BaseARPESDataLoader):
         "analyser_lens_mode": "entry1/instrument/analyser/lens_mode",
         "analyser_acquisition_mode": "entry1/instrument/analyser/acquisition_mode",
         "analyser_eV_type": "FIXED_VALUE:kinetic",
-        "analyser_deflector_parallel": "entry1/instrument/deflector_y/deflector_y",
-        "analyser_deflector_perp": "entry1/instrument/deflector_x/deflector_x",
+        "analyser_deflector_parallel": lambda f: (
+            (
+                "entry1/instrument/analyser/detector_y"
+                if parse(
+                    (
+                        (f["entry1/start_time"][()]).decode()
+                        if isinstance(f["entry1/start_time"][()], bytes)
+                        else f["entry1/start_time"][()]
+                    )
+                )
+                > datetime(2021, 7, 1, tzinfo=timezone.utc)
+                else None
+            )
+            if "entry1/start_time" in f
+            else None
+        ),
+        "analyser_deflector_perp": lambda f: (
+            (
+                "entry1/instrument/deflector_x/deflector_x"
+                if "entry1/instrument/deflector_x/deflector_x" in f
+                else "entry1/instrument/analyser/deflector_x"
+            )
+            if "entry1/start_time" in f
+            and parse(
+                f["entry1/start_time"][()].decode()
+                if isinstance(f["entry1/start_time"][()], bytes)
+                else f["entry1/start_time"][()]
+            )
+            > datetime(2021, 7, 1, tzinfo=timezone.utc)
+            else None
+        ),
         "temperature_sample": "entry1/sample/temperature",
         "temperature_cryostat": "entry1/sample/cryostat_temperature",
         "temperature_shield": "entry1/sample/shield_temperature",
@@ -505,8 +562,9 @@ class I05NanoARPESLoader(I05ARPESLoader, BaseOpticsDataLoader):
         "x3": -1,
     }
 
-    _analyser_sign_conventions = {
-        # overriden when loading data to take account of analyser upgrade see below
+    _analyser_sign_conventions = {  # This will be overridden if the analyser upgrade is detected see class I05NanoNewARPESLoader
+        "theta_par": -1,
+        "deflector_parallel": -1,  # consistent with theta_par
     }
 
     _desired_dim_order = [
@@ -529,7 +587,8 @@ class I05NanoARPESLoader(I05ARPESLoader, BaseOpticsDataLoader):
     ]
 
     _analyser_name_conventions = {
-        # deflector conventions overridden when loading data to take account of analyser upgrade see below
+        "deflector_perp": "ThetaY",  # This one and the one below will be overridden if the analyser upgrade is detected
+        "deflector_parallel": "ThetaX",  # see class I05NanoNewARPESLoader
         "eV": ["energies", "kinetic_energy_center"],
         "theta_par": "angles",
         "hv": ["energy", "value"],
@@ -735,6 +794,27 @@ class I05NanoARPESLoader(I05ARPESLoader, BaseOpticsDataLoader):
         "_parse_optics_metadata",
     ]  # List of metadata parsers to apply
 
+    # Handle nano analyser upgrade
+    _analyser_upgrade_date = datetime(2026, 4, 1, tzinfo=timezone.utc)  # DA30 --> A1
+
+    @classmethod
+    def _get_start_time(cls, fpath):
+        """Parse the acquisition start time from the file, as a tz-aware datetime."""
+        with h5py.File(fpath, "r") as f:
+            if "entry1/start_time" not in f:
+                return None
+            _raw_start_time = f["entry1/start_time"][()]
+            _raw_start_time = (
+                _raw_start_time.decode()
+                if isinstance(_raw_start_time, bytes)
+                else str(_raw_start_time)
+            )
+        start_time = parse(_raw_start_time)
+        if start_time.tzinfo is None:
+            start_time = start_time.replace(tzinfo=timezone.utc)
+        print(f"data acquired at {start_time}")
+        return start_time
+
     @classmethod
     def _load(cls, fpath, lazy, metadata, quiet, **kwargs):
         """Load the data from Diamond I05 Nano ARPES."""
@@ -743,34 +823,17 @@ class I05NanoARPESLoader(I05ARPESLoader, BaseOpticsDataLoader):
             return cls.load(fpath, loc="SES", lazy=lazy, metadata=metadata)
 
         # Choose analyser sign and name conventions for deflector based on acquisition date i.e. the analyser used at the time
-        with h5py.File(fpath, "r") as f:
-            if "entry1/start_time" in f:
-                _raw_start_time = f["entry1/start_time"][()]
-                _raw_start_time = (
-                    _raw_start_time.decode()
-                    if isinstance(_raw_start_time, bytes)
-                    else str(_raw_start_time)
+        if cls is I05NanoARPESLoader:
+            start_time = cls._get_start_time(fpath)
+            if start_time is not None and start_time > cls._analyser_upgrade_date:
+                return cls.load(
+                    fpath,
+                    loc="Diamond_I05_Nano-ARPES_New",
+                    lazy=lazy,
+                    metadata=metadata,
+                    quiet=quiet,
+                    **kwargs,
                 )
-                _after_analyser_upgrade = parse(_raw_start_time) > datetime(
-                    2026, 4, 1, tzinfo=timezone.utc
-                )
-            else:
-                _after_analyser_upgrade = False
-        cls._analyser_sign_conventions["theta_par"] = (
-            1 if _after_analyser_upgrade else -1
-        )
-        cls._analyser_sign_conventions["deflector_parallel"] = (
-            1 if _after_analyser_upgrade else -1
-        )
-        cls._analyser_sign_conventions["deflector_perp"] = (
-            -1 if _after_analyser_upgrade else 1
-        )
-        cls._analyser_name_conventions["deflector_perp"] = (
-            "deflector_x" if _after_analyser_upgrade else "ThetaY"
-        )
-        cls._analyser_name_conventions["deflector_parallel"] = (
-            "deflector_y" if _after_analyser_upgrade else "ThetaX"
-        )
 
         # Load the data
         data = super()._load(fpath, lazy, metadata, quiet, **kwargs)
@@ -842,3 +905,20 @@ class I05NanoARPESLoader(I05ARPESLoader, BaseOpticsDataLoader):
         )
 
         return corrected_data
+
+
+@register_loader
+class I05NanoNewARPESLoader(I05NanoARPESLoader):
+    """Nano branch of I05 after the 2026 analyser upgrade."""
+
+    _loc_name = "Diamond_I05_Nano-ARPES_New"
+    _analyser_sign_conventions = {
+        "theta_par": 1,
+        "deflector_parallel": 1,  # consistent with theta_par
+        "deflector_perp": -1,
+    }
+    _analyser_name_conventions = {
+        **I05NanoARPESLoader._analyser_name_conventions,
+        "deflector_perp": "deflector_x",
+        "deflector_parallel": "deflector_y",
+    }

--- a/peaks/core/fileIO/loaders/diamond.py
+++ b/peaks/core/fileIO/loaders/diamond.py
@@ -165,6 +165,28 @@ class DiamondNXSLoader(BaseHDF5DataLoader):
             f"and no signal attribute found to mark primary data in the group."
         )
 
+    @staticmethod
+    def _parse_start_time(f):
+        """Return the tz-aware acquisition start time."""
+        if "entry1/start_time" not in f:
+            return None
+        _raw_start_time = f["entry1/start_time"][()]
+        _raw_start_time = (
+            _raw_start_time.decode()
+            if isinstance(_raw_start_time, bytes)
+            else str(_raw_start_time)
+        )
+        start_time = parse(_raw_start_time)
+        if start_time.tzinfo is None:
+            start_time = start_time.replace(tzinfo=timezone.utc)
+        return start_time
+
+    @classmethod
+    def _get_start_time(cls, fpath):
+        """Parse the acquisition start time from the file at `fpath`."""
+        with h5py.File(fpath, "r") as f:
+            return cls._parse_start_time(f)
+
 
 @register_loader
 class I05ARPESLoader(DiamondNXSLoader, BaseARPESDataLoader):
@@ -210,20 +232,11 @@ class I05ARPESLoader(DiamondNXSLoader, BaseARPESDataLoader):
         "manipulator_x3": "entry1/instrument/manipulator/saz",
         "manipulator_salong": "entry1/instrument/manipulator/salong",
         "analyser_model": lambda f: (
-            (
-                "FIXED_VALUE:MBS A1"
-                if parse(
-                    (
-                        (f["entry1/start_time"][()]).decode()
-                        if isinstance(f["entry1/start_time"][()], bytes)
-                        else f["entry1/start_time"][()]
-                    )
-                )
-                > datetime(2021, 7, 1, tzinfo=timezone.utc)
-                else "FIXED_VALUE:Scienta R4000"
-            )
-            if "entry1/start_time" in f
-            else None
+            None
+            if (ac_date := DiamondNXSLoader._parse_start_time(f)) is None
+            else "FIXED_VALUE:MBS A1"
+            if ac_date > I05ARPESLoader._hr_analyser_upgrade_date
+            else "FIXED_VALUE:Scienta R4000"
         ),
         "analyser_slit_width": lambda f: (  # If the slit size is 0, assume it's not set and return None, otherwise return the value.
             None
@@ -271,19 +284,9 @@ class I05ARPESLoader(DiamondNXSLoader, BaseARPESDataLoader):
         "analyser_acquisition_mode": "entry1/instrument/analyser/acquisition_mode",
         "analyser_eV_type": "FIXED_VALUE:kinetic",
         "analyser_deflector_parallel": lambda f: (
-            (
-                "entry1/instrument/analyser/detector_y"
-                if parse(
-                    (
-                        (f["entry1/start_time"][()]).decode()
-                        if isinstance(f["entry1/start_time"][()], bytes)
-                        else f["entry1/start_time"][()]
-                    )
-                )
-                > datetime(2021, 7, 1, tzinfo=timezone.utc)
-                else None
-            )
-            if "entry1/start_time" in f
+            "entry1/instrument/analyser/detector_y"
+            if (ac_date := DiamondNXSLoader._parse_start_time(f))
+            and ac_date > I05ARPESLoader._hr_analyser_upgrade_date
             else None
         ),
         "analyser_deflector_perp": lambda f: (
@@ -292,13 +295,8 @@ class I05ARPESLoader(DiamondNXSLoader, BaseARPESDataLoader):
                 if "entry1/instrument/deflector_x/deflector_x" in f
                 else "entry1/instrument/analyser/deflector_x"
             )
-            if "entry1/start_time" in f
-            and parse(
-                f["entry1/start_time"][()].decode()
-                if isinstance(f["entry1/start_time"][()], bytes)
-                else f["entry1/start_time"][()]
-            )
-            > datetime(2021, 7, 1, tzinfo=timezone.utc)
+            if (ac_date := DiamondNXSLoader._parse_start_time(f))
+            and ac_date > I05ARPESLoader._hr_analyser_upgrade_date
             else None
         ),
         "temperature_sample": "entry1/sample/temperature",
@@ -321,6 +319,8 @@ class I05ARPESLoader(DiamondNXSLoader, BaseARPESDataLoader):
 
     _data_group_key_resolution_order = ["analyser"]
     _core_data_key_resolution_order = ["analyser"]
+
+    _hr_analyser_upgrade_date = datetime(2021, 7, 1, tzinfo=timezone.utc)  # R4000 --> A1
 
     @classmethod
     def _load_data(cls, fpath, lazy, **kwargs):
@@ -613,15 +613,7 @@ class I05NanoARPESLoader(I05ARPESLoader, BaseOpticsDataLoader):
         "manipulator_x2": "entry1/instrument/manipulator/smy",
         "manipulator_x3": "entry1/instrument/manipulator/smz",
         "manipulator_defocus": "entry1/instrument/manipulator/smdefocus",
-        "analyser_model": lambda f: (
-            None
-            if (ac_date := I05NanoARPESLoader._parse_start_time(f)) is None
-            else (
-                "FIXED_VALUE:MBS A1"
-                if ac_date > I05NanoARPESLoader._analyser_upgrade_date
-                else "FIXED_VALUE:Scienta DA30"
-            )
-        ),
+        "analyser_model": "FIXED_VALUE:Scienta DA30",  # Overridden in I05NanoNewARPESLoader to handle analyser upgrade
         "analyser_slit_width": [  # If the slit size is 0, assume it's not set and return None, otherwise return the value.
             lambda f: (
                 None
@@ -714,18 +706,8 @@ class I05NanoARPESLoader(I05ARPESLoader, BaseOpticsDataLoader):
             "entry1/instrument/analyser_total/acquisition_mode",
         ],
         "analyser_eV_type": "FIXED_VALUE:kinetic",
-        "analyser_deflector_parallel": lambda f: (
-            "entry1/instrument/analyser/deflector_y"
-            if (ac_date := I05NanoARPESLoader._parse_start_time(f))
-            and ac_date > I05NanoARPESLoader._analyser_upgrade_date
-            else None
-        ),
-        "analyser_deflector_perp": lambda f: (
-            "entry1/instrument/analyser/deflector_x"
-            if (ac_date := I05NanoARPESLoader._parse_start_time(f))
-            and ac_date > I05NanoARPESLoader._analyser_upgrade_date
-            else None
-        ),
+        "analyser_deflector_parallel": None,  # Overridden in I05NanoNewARPESLoader to handle analyser upgrade
+        "analyser_deflector_perp": None,  # Overridden in I05NanoNewARPESLoader to handle analyser upgrade
         "analyser_polar": [
             "entry1/instrument/analyser/analyser_polar_angle",
             "entry1/instrument/analyser_total/analyser_polar_angle",
@@ -766,29 +748,9 @@ class I05NanoARPESLoader(I05ARPESLoader, BaseOpticsDataLoader):
     ]  # List of metadata parsers to apply
 
     # Handle nano analyser upgrade
-    _analyser_upgrade_date = datetime(2026, 4, 1, tzinfo=timezone.utc)  # DA30 --> A1
-
-    @staticmethod
-    def _parse_start_time(f):
-        """Return the tz-aware acquisition start time."""
-        if "entry1/start_time" not in f:
-            return None
-        _raw_start_time = f["entry1/start_time"][()]
-        _raw_start_time = (
-            _raw_start_time.decode()
-            if isinstance(_raw_start_time, bytes)
-            else str(_raw_start_time)
-        )
-        start_time = parse(_raw_start_time)
-        if start_time.tzinfo is None:
-            start_time = start_time.replace(tzinfo=timezone.utc)
-        return start_time
-
-    @classmethod
-    def _get_start_time(cls, fpath):
-        """Parse the acquisition start time from the file at `fpath`."""
-        with h5py.File(fpath, "r") as f:
-            return cls._parse_start_time(f)
+    _nano_analyser_upgrade_date = datetime(
+        2026, 4, 1, tzinfo=timezone.utc
+    )  # DA30 --> A1
 
     @classmethod
     def _load(cls, fpath, lazy, metadata, quiet, **kwargs):
@@ -798,9 +760,10 @@ class I05NanoARPESLoader(I05ARPESLoader, BaseOpticsDataLoader):
             return cls.load(fpath, loc="SES", lazy=lazy, metadata=metadata)
 
         # Choose analyser sign and name conventions for deflector based on acquisition date i.e. the analyser used at the time
+        # If data are acquired after the analyser upgrade, assign the new analyser sign and name conventions
         if cls is I05NanoARPESLoader:
             start_time = cls._get_start_time(fpath)
-            if start_time is not None and start_time > cls._analyser_upgrade_date:
+            if start_time is not None and start_time > cls._nano_analyser_upgrade_date:
                 return cls.load(
                     fpath,
                     loc="Diamond_I05_Nano-ARPES_New",
@@ -896,4 +859,11 @@ class I05NanoNewARPESLoader(I05NanoARPESLoader):
         **I05NanoARPESLoader._analyser_name_conventions,
         "deflector_perp": "deflector_x",
         "deflector_parallel": "deflector_y",
+    }
+
+    _hdf5_metadata_key_mappings = {
+        **I05NanoARPESLoader._hdf5_metadata_key_mappings,
+        "analyser_model": "FIXED_VALUE:MBS A1",
+        "analyser_deflector_parallel": "entry1/instrument/analyser/deflector_y",
+        "analyser_deflector_perp": "entry1/instrument/analyser/deflector_x",
     }

--- a/peaks/core/fileIO/loaders/diamond.py
+++ b/peaks/core/fileIO/loaders/diamond.py
@@ -225,7 +225,6 @@ class I05ARPESLoader(DiamondNXSLoader, BaseARPESDataLoader):
             if "entry1/start_time" in f
             else None
         ),
-        # "analyser_slit_width": "entry1/instrument/analyser/entrance_slit_size",
         "analyser_slit_width": lambda f: (  # If the slit size is 0, assume it's not set and return None, otherwise return the value.
             None
             if (
@@ -236,7 +235,6 @@ class I05ARPESLoader(DiamondNXSLoader, BaseARPESDataLoader):
             == 0
             else v
         ),
-        # "analyser_slit_width_identifier": "entry1/instrument/analyser_total/entrance_slit_setting",
         "analyser_slit_width_identifier": [
             lambda f: (
                 None  # If the slit size is 0 which is physcially impossible, assume it's not set and return None
@@ -616,20 +614,13 @@ class I05NanoARPESLoader(I05ARPESLoader, BaseOpticsDataLoader):
         "manipulator_x3": "entry1/instrument/manipulator/smz",
         "manipulator_defocus": "entry1/instrument/manipulator/smdefocus",
         "analyser_model": lambda f: (
-            (
+            None
+            if (ac_date := I05NanoARPESLoader._parse_start_time(f)) is None
+            else (
                 "FIXED_VALUE:MBS A1"
-                if parse(
-                    (
-                        (f["entry1/start_time"][()]).decode()
-                        if isinstance(f["entry1/start_time"][()], bytes)
-                        else f["entry1/start_time"][()]
-                    )
-                )
-                > datetime(2026, 4, 1, tzinfo=timezone.utc)
+                if ac_date > I05NanoARPESLoader._analyser_upgrade_date
                 else "FIXED_VALUE:Scienta DA30"
             )
-            if "entry1/start_time" in f
-            else None
         ),
         "analyser_slit_width": [  # If the slit size is 0, assume it's not set and return None, otherwise return the value.
             lambda f: (
@@ -724,35 +715,15 @@ class I05NanoARPESLoader(I05ARPESLoader, BaseOpticsDataLoader):
         ],
         "analyser_eV_type": "FIXED_VALUE:kinetic",
         "analyser_deflector_parallel": lambda f: (
-            (
-                "entry1/instrument/analyser/deflector_y"
-                if parse(
-                    (
-                        (f["entry1/start_time"][()]).decode()
-                        if isinstance(f["entry1/start_time"][()], bytes)
-                        else f["entry1/start_time"][()]
-                    )
-                )
-                > datetime(2026, 4, 1, tzinfo=timezone.utc)
-                else None
-            )
-            if "entry1/start_time" in f
+            "entry1/instrument/analyser/deflector_y"
+            if (ac_date := I05NanoARPESLoader._parse_start_time(f))
+            and ac_date > I05NanoARPESLoader._analyser_upgrade_date
             else None
         ),
         "analyser_deflector_perp": lambda f: (
-            (
-                "entry1/instrument/analyser/deflector_x"
-                if parse(
-                    (
-                        (f["entry1/start_time"][()]).decode()
-                        if isinstance(f["entry1/start_time"][()], bytes)
-                        else f["entry1/start_time"][()]
-                    )
-                )
-                > datetime(2026, 4, 1, tzinfo=timezone.utc)
-                else None
-            )
-            if "entry1/start_time" in f
+            "entry1/instrument/analyser/deflector_x"
+            if (ac_date := I05NanoARPESLoader._parse_start_time(f))
+            and ac_date > I05NanoARPESLoader._analyser_upgrade_date
             else None
         ),
         "analyser_polar": [
@@ -797,23 +768,27 @@ class I05NanoARPESLoader(I05ARPESLoader, BaseOpticsDataLoader):
     # Handle nano analyser upgrade
     _analyser_upgrade_date = datetime(2026, 4, 1, tzinfo=timezone.utc)  # DA30 --> A1
 
-    @classmethod
-    def _get_start_time(cls, fpath):
-        """Parse the acquisition start time from the file, as a tz-aware datetime."""
-        with h5py.File(fpath, "r") as f:
-            if "entry1/start_time" not in f:
-                return None
-            _raw_start_time = f["entry1/start_time"][()]
-            _raw_start_time = (
-                _raw_start_time.decode()
-                if isinstance(_raw_start_time, bytes)
-                else str(_raw_start_time)
-            )
+    @staticmethod
+    def _parse_start_time(f):
+        """Return the tz-aware acquisition start time."""
+        if "entry1/start_time" not in f:
+            return None
+        _raw_start_time = f["entry1/start_time"][()]
+        _raw_start_time = (
+            _raw_start_time.decode()
+            if isinstance(_raw_start_time, bytes)
+            else str(_raw_start_time)
+        )
         start_time = parse(_raw_start_time)
         if start_time.tzinfo is None:
             start_time = start_time.replace(tzinfo=timezone.utc)
-        print(f"data acquired at {start_time}")
         return start_time
+
+    @classmethod
+    def _get_start_time(cls, fpath):
+        """Parse the acquisition start time from the file at `fpath`."""
+        with h5py.File(fpath, "r") as f:
+            return cls._parse_start_time(f)
 
     @classmethod
     def _load(cls, fpath, lazy, metadata, quiet, **kwargs):

--- a/tutorials/6_data_fitting.ipynb
+++ b/tutorials/6_data_fitting.ipynb
@@ -326,7 +326,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fit_result.plot_fit(figsize=(8,8))"
+    "fit_result.plot_fit()"
    ]
   },
   {

--- a/tutorials/6_data_fitting.ipynb
+++ b/tutorials/6_data_fitting.ipynb
@@ -36,8 +36,25 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "2",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "from pint import UnitStrippedWarning\n",
+    "# This cell is to suppress the warnings on docs builds for now\n",
+    "warnings.filterwarnings(\"ignore\", category=UnitStrippedWarning)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
    "metadata": {},
    "source": [
     "This tutorial gives a brief introduction to fitting data within `peaks`. `peaks` utilises [`lmfit`](https://lmfit.github.io/lmfit-py/) for fitting data, with some added or adapted methods to ease using this with data in a {py:class}`xarray.DataArray` format, and some additional helper functions. The user should be familiar with [`lmfit`](https://lmfit.github.io/lmfit-py/) Models and methodoligies, see the [`lmfit` documentation](https://lmfit.github.io/lmfit-py/).\n",
@@ -60,7 +77,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "## General peak fitting\n",
@@ -71,7 +88,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -83,7 +100,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,7 +111,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "source": [
     "We'll fit this with the following model:\n",
@@ -109,7 +126,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -118,7 +135,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "source": [
     "Now we build the model and initialise the parameters. The initial model is built using the `peaks`-wrapped versions of the standard models combined with binary operators (forming a {py:class}`lmfit.model.CompositeModel`), and then this is passed to the {py:func}`peaks.core.fitting.models.GaussianConvolvedFitModel` to add the Gaussian convolution."
@@ -127,7 +144,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -144,7 +161,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -154,20 +171,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "source": [
     "We can manually enter sensible starting parameters, e.g.:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "12",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "params = model.make_params(sigma_conv=dict(value=0.1, vary=False))  # e.g. fix the resolution "
    ]
   },
   {
@@ -177,12 +184,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "params = model.make_params(sigma_conv=dict(value=0.1, vary=False))  # e.g. fix the resolution "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "params"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "source": [
     "Or we can make use of the estimating capabilities of the individual models. This is not implemeted for all models, but is for most. It also does not work for the complete composite model in one go, and so we iterate through each peak and component in turn..."
@@ -191,7 +208,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,7 +223,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -230,7 +247,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "source": [
     "We can plot the calcuated model using our guessed parameters on top of our data"
@@ -239,7 +256,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -248,7 +265,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "source": [
     "This looks a reasonable starting point, so we can now fit the model. For this, we can make use of the {py:mod}`peaks.core.fitting.fit` method, passing the data as an {py:class}`xarray.DataArray`. As this is a 1D DataArray, we do not need to explicitly specify the independent dimension (but we would if we had passed a higher dimensional array)."
@@ -257,7 +274,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -266,20 +283,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "source": [
     "This returns a {py:class}`xarray.Dataset` which contains the results of the fit and standard errors as variables, as well as the full {py:class}`lmfit.model.ModelResult`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "22",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fit_result"
    ]
   },
   {
@@ -289,13 +296,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "fit_result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Full lmfit ModelResult\n",
     "fit_result['fit_model'].values[()]"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "source": [
     "#### Plotting fits\n",
@@ -305,7 +322,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -314,7 +331,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "source": [
     "#### Saving and loading fits\n",
@@ -324,7 +341,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -336,7 +353,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "source": [
     "## Fitting multi-dimensional data\n",
@@ -346,7 +363,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -366,7 +383,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -376,7 +393,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -385,7 +402,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "source": [
     "As we have now masked the data in a way that leaves NaNs at the edges for some of the data sets, we need to ensure the fit model can cope with this. To do this, we set the model {py:attr}`nan_policy <lmfit.model.nan_policy>`:"
@@ -394,7 +411,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -403,7 +420,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "source": [
     "For a 2D DataArray like this, we can choose to fit the data sequentially, where the result from the previous fit is used to initiate the starting parameters of the next fit, or using the same starting parameters for all fits (the latter also allows fitting the data using parallel processing). We will use the sequential mode here, which is the default when we are fitting 2D data.  "
@@ -412,7 +429,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -423,7 +440,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "source": [
     "We can now plot the relevant results of the fit directly from the returned dataset."
@@ -432,7 +449,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -453,7 +470,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "source": [
     "Calling the {py:func}`~peaks.core.display.plotting.plot_fit` function on the fit result will now allow us to dynamically explore the fits and their residuals"
@@ -462,7 +479,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -471,7 +488,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "source": [
     "### Dask arrays\n",
@@ -487,7 +504,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -501,7 +518,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -511,7 +528,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -523,7 +540,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -538,7 +555,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -547,7 +564,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "source": [
     "No fitting has been performed yet (note that this was extremely quick!), but we can still access the fit results plot, with the fits being performed as required"
@@ -556,7 +573,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -565,7 +582,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "source": [
     "And we can make plots of relevant fit results"
@@ -574,7 +591,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -585,7 +602,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "source": [
     "(fitting-au-fermi-edge-data)=\n",
@@ -597,7 +614,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -608,7 +625,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "source": [
     "We can pass a single EDC:"
@@ -617,7 +634,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -626,7 +643,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "source": [
     "The fitted Fermi energy is also stored in the fit_result attributes"
@@ -635,7 +652,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -644,7 +661,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "source": [
     "Or we can pass the measured angular-dependent Au reference, optionally specifying the type of function (polynomaial, average etc.) used to determine the Fermi level dependence on detector angle (via the `EF_correction_type` parameter; defaults to polynomail of order 4)"
@@ -653,7 +670,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -662,7 +679,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "source": [
     "The results of the `EF_correction` fit are stored as a dictionary in the fit results attribute"
@@ -671,7 +688,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -680,7 +697,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "source": [
     "## Quick fitting\n",
@@ -691,7 +708,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -701,7 +718,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -710,7 +727,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "source": [
     "This returns the usual `peaks` {py:class}`xarray.Dataset` fit_result. The parameters can be seen directly: "
@@ -719,7 +736,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -728,7 +745,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "65",
+   "id": "66",
    "metadata": {},
    "source": [
     "Or the plot can be returned as usual:"
@@ -737,7 +754,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -746,7 +763,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "67",
+   "id": "68",
    "metadata": {},
    "source": [
     "This method scales to higher-dimensional data as for the full fit methods:"
@@ -755,7 +772,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -765,7 +782,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69",
+   "id": "70",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -773,7 +790,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
## Display panels
When a normal emission angle is zero as a floating-point value, copying the normal emission values produces a [pretty format](https://pint.readthedocs.io/en/stable/user/formatting.html#string-formatting-specification), e.g. `10⁻⁶`, that `set_normal_emission` can't parse. So this now uses the default plain format instead.

## Updates on I05 loader

### Nano branch

Context: the nano branch has recently switched from the DA30 to an MBS A1 analyser, and 1/4/26 can be used as the cut-off.

- ~~analyser sign&naming conventions: overridden in `_load`, which selects the correct set of conventions based on the acquisition date.~~ No this is a wrong fix. Class attributes are shared across instances. Will causes bugs when working with both new and old data.
- analyser sign&naming conventions: had to add a new class `I05NanoNewARPESLoader` to deal with this. Apply the new conventions when the acquisition date is after the upgrade date
- analyser_model: same as above. Defined in the new class.
- analyser slit and its identifier: don't think the hardware supports embedding this information in the metadata yet, and the slit currently reads 0 in the metadata now. The parsing logic treats a slit width of 0 as not yet set and returns None for both the slit width and the slit identifier; otherwise return as-is.

### HR branch

- fix the metadata display for deflector angles and slit

## Multiple fit plots

- Now embed static plots in docs
- added a new parameter to `plot_fit` allowing setting the the height of the matplotlib pane for multiple fits
- wrap the too-long title inherited from `lmfit` that made the figure and font size tiny