### PR TITLE
Improve compatibility a bit for wider execution frameworks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `plot_grid` renders with a distorted aspect ratio in marimo notebooks when the figure is wider than the notebook column ([PR#56](https://github.com/phrgab/peaks/pull/56))
+
 ### Changed
+
+- Limit font size and max lines of titles in `plot_fit` outputs ([PR#56](https://github.com/phrgab/peaks/pull/56))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Progress bar support for running in marimo notebooks. `analysis_warning`s now render as native marimo callouts when running inside marimo ([PR#56](https://github.com/phrgab/peaks/pull/56))
+
 ### Fixed
 
 ### Changed

--- a/peaks/core/display/plotting.py
+++ b/peaks/core/display/plotting.py
@@ -14,7 +14,7 @@ from matplotlib import cm, colors
 from matplotlib.figure import Figure
 from numpy.fft import fft
 
-from peaks.core.utils.misc import analysis_warning
+from peaks.core.utils.misc import _in_marimo, analysis_warning
 
 
 def plot_grid(
@@ -194,6 +194,21 @@ def plot_grid(
 
     # Tidy up the layout
     plt.tight_layout()
+
+    if _in_marimo():
+        fig_width_px = fig.get_figwidth() * fig.dpi
+        if fig_width_px > 1100:  # roughly the max width of the marimo pane
+            import io
+
+            import marimo as mo
+
+            buf = io.BytesIO()
+            fig.savefig(buf, format="png", dpi=fig.dpi, bbox_inches="tight")
+            buf.seek(
+                0
+            )  # Rewind the buffer to the beginning so it can be read from the start
+            plt.close(fig)
+            return mo.image(buf, width=1100)
 
 
 def plot_DCs(
@@ -550,7 +565,12 @@ def plot_fit(
         for a in fig.axes:
             title = a.get_title()
             if title:
-                a.set_title("\n".join(textwrap.wrap(title, width=65)))
+                a.set_title(
+                    "\n".join(
+                        textwrap.wrap(title, width=75, max_lines=4, placeholder=" …")
+                    ),
+                    fontsize="small",
+                )
         if show_components and len(fit_model.components) > 1:
             ax = next(
                 (a for a in fig.axes if "residual" not in a.get_ylabel().lower()),

--- a/peaks/core/fileIO/data_loading.py
+++ b/peaks/core/fileIO/data_loading.py
@@ -5,7 +5,7 @@ import os
 
 import dask
 import pint
-from tqdm.notebook import tqdm
+from tqdm.auto import tqdm
 
 from peaks.core.fileIO.base_data_classes.base_data_class import BaseDataLoader
 from peaks.core.options import opts

--- a/peaks/core/fileIO/loaders/casiopee.py
+++ b/peaks/core/fileIO/loaders/casiopee.py
@@ -7,7 +7,7 @@ from os.path import isfile, join
 import natsort
 import numpy as np
 import pint_xarray
-from tqdm.notebook import tqdm
+from tqdm.auto import tqdm
 
 from peaks.core.fileIO.base_arpes_data_classes.base_ses_class import SESDataLoader
 from peaks.core.fileIO.loc_registry import register_loader

--- a/peaks/core/fileIO/loaders/clf.py
+++ b/peaks/core/fileIO/loaders/clf.py
@@ -5,7 +5,7 @@ import numpy as np
 import pint_xarray
 import xarray as xr
 from scipy import constants
-from tqdm.notebook import tqdm
+from tqdm.auto import tqdm
 
 from peaks.core.fileIO.base_arpes_data_classes.base_arpes_data_class import (
     BaseARPESDataLoader,

--- a/peaks/core/fitting/fit.py
+++ b/peaks/core/fitting/fit.py
@@ -5,7 +5,7 @@ import numpy as np
 import xarray as xr
 from scipy.ndimage import gaussian_filter1d
 from scipy.signal import find_peaks
-from tqdm.notebook import tqdm
+from tqdm.auto import tqdm
 
 from peaks.core.fitting.models import LinearDosFermiModel
 from peaks.core.utils.misc import analysis_warning

--- a/peaks/core/process/k_conversion.py
+++ b/peaks/core/process/k_conversion.py
@@ -7,7 +7,7 @@ import pint
 import pint_xarray
 import xarray as xr
 from scipy.constants import angstrom, electron_volt, hbar, m_e
-from tqdm.notebook import tqdm
+from tqdm.auto import tqdm
 
 from peaks.core.fileIO.base_data_classes.base_data_class import BaseDataLoader
 from peaks.core.process.fermi_level_correction import (

--- a/peaks/core/utils/misc.py
+++ b/peaks/core/utils/misc.py
@@ -1,8 +1,10 @@
 """Miscellaneous helper functions."""
 
 import contextlib
+import sys
 import time
 import warnings
+from typing import Literal
 
 import xarray as xr
 from dask.callbacks import Callback
@@ -10,9 +12,20 @@ from IPython.display import Javascript, Markdown, display
 from termcolor import colored
 from tqdm.auto import tqdm
 
+_CalloutKind = Literal["neutral", "warn", "success", "info", "danger"]
+
+# Map peaks/bootstrap warning types to marimo callout kinds
+_MARIMO_CALLOUT_KINDS: dict[str, _CalloutKind] = {
+    "info": "info",
+    "warning": "warn",
+    "success": "success",
+    "danger": "danger",
+}
+
 
 def analysis_warning(text, warn_type="info", title="Analysis info", quiet=False):
     """Tool to display a string as a warning in a formatted box.
+    In marimo notebooks, renders as a ``marimo.callout`` instead.
 
     Parameters
     ----------
@@ -47,12 +60,18 @@ def analysis_warning(text, warn_type="info", title="Analysis info", quiet=False)
     """
     # Display warning
     if not quiet:
-        display(
-            Markdown(
-                '<div class="alert alert-block alert-%s"><b>%s: </b> %s </div>'
-                % (warn_type, title, text)
+        if _in_marimo():
+            import marimo as mo
+
+            w_kind = _MARIMO_CALLOUT_KINDS.get(warn_type, "info")
+            mo.output.append(mo.callout(mo.md(f"**{title}:** {text}"), kind=w_kind))
+        else:
+            display(
+                Markdown(
+                    '<div class="alert alert-block alert-%s"><b>%s: </b> %s </div>'
+                    % (warn_type, title, text)
+                )
             )
-        )
 
 
 def dequantify_quantify_wrapper(func):
@@ -239,3 +258,14 @@ class DaskTQDMProgressBar(Callback):
     def _finish(self, dsk, state, errored):
         if self._tqdm:
             self._tqdm.close()
+
+
+def _in_marimo():
+    """Return True if running inside a marimo notebook."""
+    mo = sys.modules.get("marimo")
+    if mo is None:
+        return False
+    try:
+        return bool(mo.running_in_notebook())
+    except AttributeError:
+        return False

--- a/peaks/core/utils/sample_data.py
+++ b/peaks/core/utils/sample_data.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import requests
 from IPython.display import HTML, Video
 from requests.adapters import HTTPAdapter
-from tqdm.notebook import tqdm
+from tqdm.auto import tqdm
 from urllib3.util.retry import Retry
 
 from peaks.core.fileIO.data_loading import load

--- a/tests/core/utils/test_misc.py
+++ b/tests/core/utils/test_misc.py
@@ -1,11 +1,14 @@
+import sys
+import types
 import warnings
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pint
 import pytest
 import xarray as xr
 
 from peaks.core.utils.misc import (
+    _in_marimo,
     analysis_warning,
     dequantify_quantify_wrapper,
     format_colored_dict,
@@ -45,6 +48,17 @@ class TestFormatColouredDict:
         assert colored("sapolar", "green") in result
 
 
+class TestInMarimo:
+    def test_false_when_marimo_not_imported(self, monkeypatch):
+        monkeypatch.delitem(sys.modules, "marimo", raising=False)
+        assert _in_marimo() is False
+
+    def test_true_when_running_in_mo_nb(self, monkeypatch):
+        fake_mo = types.SimpleNamespace(running_in_notebook=lambda: True)
+        monkeypatch.setitem(sys.modules, "marimo", fake_mo)
+        assert _in_marimo() is True
+
+
 class TestAnalysisWarning:
     @patch("peaks.core.utils.misc.display")
     def test_displays(self, mock_display):
@@ -61,6 +75,18 @@ class TestAnalysisWarning:
         for warn_type in ("info", "warning", "success", "danger"):
             analysis_warning("a message", warn_type=warn_type)
         assert mock_display.call_count == 4
+
+    @patch("peaks.core.utils.misc._in_marimo", return_value=True)
+    def test_appends_mo_callout_not_jupyter_display(self, mock_in_marimo, monkeypatch):
+        fake_mo = MagicMock()
+        monkeypatch.setitem(sys.modules, "marimo", fake_mo)
+
+        with patch("peaks.core.utils.misc.display") as mock_jupyter_display:
+            analysis_warning("a message", warn_type="warning", title="Test")
+
+        fake_mo.output.append.assert_called_once()
+        assert fake_mo.callout.call_args.kwargs["kind"] == "warn"
+        mock_jupyter_display.assert_not_called()
 
 
 class TestPintDequantifyQuantifyWrapper:


### PR DESCRIPTION
As part of our plan to support broader execution frameworks, just to chuck in a few tweaks to make using marimo a wee bit smoother.

- switched `tqdm.notebook` to `tqdm.auto`. In jupyter `tqdm.auto` returns the same class as `tqdm.notebook` so the jupyter behaviour is unchagned
- `analysis_warning` now renders a native marimo callout when running in marimo, detected via a new `_in_marimo` helper. Jupyter display is untouched as well. Associated tests have been added.
- fixed distorted `plot_grid` output in marimo notebooks. Again this doesn't affect jupyter