### PR TITLE
Fix spatial map edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `plot_grid` renders with a distorted aspect ratio in marimo notebooks when the figure is wider than the notebook column ([PR#56](https://github.com/phrgab/peaks/pull/56))
-- `ZeroDivisionError` in `disp` colour bar for constant-value data slices
-- Metadata reports `[nan, nan]` when a scan contains a few NaN readbacks
+- `ZeroDivisionError` in `disp` colour bar for constant-value data slices ([PR#57](https://github.com/phrgab/peaks/pull/57))
+- Metadata reports `[nan, nan]` when a scan contains a few NaN readbacks ([PR#57](https://github.com/phrgab/peaks/pull/57))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `plot_grid` renders with a distorted aspect ratio in marimo notebooks when the figure is wider than the notebook column ([PR#56](https://github.com/phrgab/peaks/pull/56))
+- `ZeroDivisionError` in `disp` colour bar for constant-value data slices
+- Metadata reports `[nan, nan]` when a scan contains a few NaN readbacks
 
 ### Changed
 

--- a/peaks/core/GUI/disp_panels/disp_2d.py
+++ b/peaks/core/GUI/disp_panels/disp_2d.py
@@ -407,12 +407,14 @@ class _Disp2D(QtWidgets.QMainWindow):
         )
 
         # Add colour bar
+        c_span = abs(self.c_max - self.c_min)
         self.colorbar = pg.ColorBarItem(
             label=self.current_data.name,
             colorMap=cmap,
             colorMapMenu=True,
             limits=(self.c_min, self.c_max),
-            rounding=min(abs(self.c_max - self.c_min) / 2000, 1),
+            rounding=min(c_span / 2000, 1) if c_span > 0 else 1e-9,
+            # rounding=min(abs(self.c_max - self.c_min) / 2000, 1),
             interactive=True,
             orientation="h",
             values=c_range,

--- a/peaks/core/GUI/disp_panels/disp_2d.py
+++ b/peaks/core/GUI/disp_panels/disp_2d.py
@@ -414,7 +414,6 @@ class _Disp2D(QtWidgets.QMainWindow):
             colorMapMenu=True,
             limits=(self.c_min, self.c_max),
             rounding=min(c_span / 2000, 1) if c_span > 0 else 1e-9,
-            # rounding=min(abs(self.c_max - self.c_min) / 2000, 1),
             interactive=True,
             orientation="h",
             values=c_range,

--- a/peaks/core/GUI/disp_panels/disp_3d.py
+++ b/peaks/core/GUI/disp_panels/disp_3d.py
@@ -529,7 +529,6 @@ class _Disp3D(QtWidgets.QMainWindow):
             colorMapMenu=True,
             limits=(self.c_min, self.c_max),
             rounding=min(c_span / 2000, 1) if c_span > 0 else 1e-9,
-            # rounding=min(abs(self.c_max - self.c_min) / 2000, 1),
             interactive=True,
             orientation="h",
             values=(self.c_min, self.c_max),

--- a/peaks/core/GUI/disp_panels/disp_3d.py
+++ b/peaks/core/GUI/disp_panels/disp_3d.py
@@ -521,13 +521,15 @@ class _Disp3D(QtWidgets.QMainWindow):
         self.image_plots[1].addItem(self.alignment_aid_shape)
 
         # Add colour bar to main image
+        c_span = abs(self.c_max - self.c_min)
         self.cmap = pg.colormap.get("Greys", source="matplotlib")
         self.colorbar = pg.ColorBarItem(
             label=self.data.name,
             colorMap=self.cmap,
             colorMapMenu=True,
             limits=(self.c_min, self.c_max),
-            rounding=min(abs(self.c_max - self.c_min) / 2000, 1),
+            rounding=min(c_span / 2000, 1) if c_span > 0 else 1e-9,
+            # rounding=min(abs(self.c_max - self.c_min) / 2000, 1),
             interactive=True,
             orientation="h",
             values=(self.c_min, self.c_max),

--- a/peaks/core/GUI/disp_panels/disp_4d.py
+++ b/peaks/core/GUI/disp_panels/disp_4d.py
@@ -130,6 +130,7 @@ class _Disp4D(QtWidgets.QMainWindow):
         self.data_explorer_disp2d = self._build_data_explorer_2D_column(
             layout, self.data.isel({self.dims[0]: 0, self.dims[1]: 0})
         )
+        print(f"self.dims[0]: {self.dims[0]}")
 
     def _build_roi_tab(self, roi_tab):
         """Build the region of interest tab layout."""

--- a/peaks/core/GUI/disp_panels/disp_4d.py
+++ b/peaks/core/GUI/disp_panels/disp_4d.py
@@ -130,7 +130,6 @@ class _Disp4D(QtWidgets.QMainWindow):
         self.data_explorer_disp2d = self._build_data_explorer_2D_column(
             layout, self.data.isel({self.dims[0]: 0, self.dims[1]: 0})
         )
-        print(f"self.dims[0]: {self.dims[0]}")
 
     def _build_roi_tab(self, roi_tab):
         """Build the region of interest tab layout."""

--- a/peaks/core/fileIO/base_data_classes/base_hdf5_class.py
+++ b/peaks/core/fileIO/base_data_classes/base_hdf5_class.py
@@ -135,7 +135,7 @@ class BaseHDF5DataLoader:
                         while isinstance(value, (np.ndarray, list)):
                             value = value[0]
                     elif return_extreme_values:
-                        value = np.array([np.min(value), np.max(value)])
+                        value = np.array([np.nanmin(value), np.nanmax(value)])
                         if value[0] == value[-1]:
                             value = value[0]
 


### PR DESCRIPTION
- guard against a zero colour range, which would make `rounding` zero and cause pyqtgraph to divide by zero when calling .disp 
- switched from `min` `max` to `nanmin` `nanmax` so that a NaN doesn't propagate through `_extract_hdf5_value` and collapse the entire range to `[nan, nan]` in the metadata display