### PR TITLE
Remove hard-coded defocus dim in plot_nanofocus and repeated points at the end in anapolar maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `plot_grid` renders with a distorted aspect ratio in marimo notebooks when the figure is wider than the notebook column ([PR#56](https://github.com/phrgab/peaks/pull/56))
 - `ZeroDivisionError` in `disp` colour bar for constant-value data slices ([PR#57](https://github.com/phrgab/peaks/pull/57))
 - Metadata reports `[nan, nan]` when a scan contains a few NaN readbacks ([PR#57](https://github.com/phrgab/peaks/pull/57))
+- Hard-coded `focus` dimension in `plot_nanofocus` ([PR#58](https://github.com/phrgab/peaks/pull/58))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ZeroDivisionError` in `disp` colour bar for constant-value data slices ([PR#57](https://github.com/phrgab/peaks/pull/57))
 - Metadata reports `[nan, nan]` when a scan contains a few NaN readbacks ([PR#57](https://github.com/phrgab/peaks/pull/57))
 - Hard-coded `focus` dimension in `plot_nanofocus` ([PR#58](https://github.com/phrgab/peaks/pull/58))
+- Non-monotonic and repeated data at end of travel in i05 nano ana_polar maps ([PR#58](https://github.com/phrgab/peaks/pull/58))
 
 ### Changed
 

--- a/peaks/core/display/plotting.py
+++ b/peaks/core/display/plotting.py
@@ -937,7 +937,7 @@ def plot_kz_cut(
         )
 
 
-def plot_nanofocus(data, focus="zpz"):
+def plot_nanofocus(data, focus=None):
     """Function to determine the focus of a scan obtained at the nano branch of the I05 beamline at Diamond Light
     Source, and plot the results.
 
@@ -964,6 +964,23 @@ def plot_nanofocus(data, focus="zpz"):
         focus_scan.plot_nanofocus()
 
     """
+    # Check if the focus dimension is specified, and if not, try to guess it from the data
+    if not focus:
+        # If no focus dimension is specified, try to guess it from the data
+        if "defocus" in data.dims:
+            focus = "defocus"
+        elif "zpz" in data.dims:
+            focus = "zpz"
+        elif "smdefocus" in data.dims:
+            focus = "smdefocus"
+        elif "laserz" in data.dims:
+            focus = "laserz"
+        else:
+            raise ValueError(
+                "No focus dimension specified and could not be guessed from the data. Please specify the focus "
+                "dimension."
+            )
+
     # Ensure the data is a 2D DataArray by integrating in energy and angle space if required
     if len(data.dims) == 4:
         data = data.mean(["theta_par", "eV"], keep_attrs=True)

--- a/peaks/core/display/plotting.py
+++ b/peaks/core/display/plotting.py
@@ -937,7 +937,7 @@ def plot_kz_cut(
         )
 
 
-def plot_nanofocus(data, focus="defocus"):
+def plot_nanofocus(data, focus="zpz"):
     """Function to determine the focus of a scan obtained at the nano branch of the I05 beamline at Diamond Light
     Source, and plot the results.
 
@@ -1007,7 +1007,7 @@ def plot_nanofocus(data, focus="defocus"):
     # along the spatial dimension
     mean_abs_deriv_smoothed = mean_abs_deriv.smooth(**{focus: 2 * focus_step})
     mean_abs_deriv_smoothed.plot(ax=axes[1, 0], c="black", alpha=0.2)
-    max_mean_abs_deriv = mean_abs_deriv_smoothed.argmax(dim="defocus")
+    max_mean_abs_deriv = mean_abs_deriv_smoothed.argmax(dim=focus)
     focal_point_mean_abs_deriv = mean_abs_deriv[focus].data[max_mean_abs_deriv]
     axes[1, 0].set_title(
         "Mean of the abs(deriv) estimate: {focal_point}".format(
@@ -1028,7 +1028,7 @@ def plot_nanofocus(data, focus="defocus"):
     # along the spatial dimension
     max_abs_deriv_smoothed = max_abs_deriv.smooth(**{focus: 2 * focus_step})
     max_abs_deriv_smoothed.plot(ax=axes[1, 1], c="black", alpha=0.2)
-    max_max_abs_deriv = max_abs_deriv_smoothed.argmax(dim="defocus")
+    max_max_abs_deriv = max_abs_deriv_smoothed.argmax(dim=focus)
     focal_point_max_abs_deriv = max_abs_deriv[focus].data[max_max_abs_deriv]
     axes[1, 1].set_title(
         "Max of the abs(deriv) estimate: {focal_point}".format(
@@ -1047,7 +1047,7 @@ def plot_nanofocus(data, focus="defocus"):
     # Estimate and plot the focal point from the focus-dependent variance along the spatial dimension
     variance_smoothed = variance.smooth(**{focus: 2 * focus_step})
     variance_smoothed.plot(ax=axes[2, 0], c="black", alpha=0.2)
-    max_variance = variance_smoothed.argmax(dim="defocus")
+    max_variance = variance_smoothed.argmax(dim=focus)
     focal_point_max_variance = variance[focus].data[max_variance]
     axes[2, 0].set_title(
         "Max of the variance estimate: {focal_point}".format(
@@ -1076,7 +1076,7 @@ def plot_nanofocus(data, focus="defocus"):
     # Estimate and plot the focal point from the FFT analysis
     FFT_data_out_smoothed = FFT_data_out.smooth(**{focus: 2 * focus_step})
     FFT_data_out_smoothed.plot(ax=axes[2, 1], c="black", alpha=0.2)
-    max_FFT = FFT_data_out_smoothed.argmax(dim="defocus")
+    max_FFT = FFT_data_out_smoothed.argmax(dim=focus)
     focal_point_max_FFT = FFT_data_out[focus].data[max_FFT]
     axes[2, 1].set_title(
         "Fast Fourier transform estimate: {focal_point}".format(

--- a/peaks/core/fileIO/loaders/diamond.py
+++ b/peaks/core/fileIO/loaders/diamond.py
@@ -508,21 +508,27 @@ class I05ARPESLoader(DiamondNXSLoader, BaseARPESDataLoader):
                         break
         da = da.rename(dim_names_to_update)
 
-        # EDGE CASE - Handle problem with ana_polar data sometimes having non-monotonic points at end of range
+        # EDGE CASE - Handle problem with ana_polar data sometimes having non-monotonic/repeated points at end of range
+        # Trim back to the last point where the axis was genuinely moving.
         if "ana_polar" in da.dims:
-            trim = 0
-            while not (
-                da.indexes["ana_polar"].is_monotonic_increasing
-                or da.indexes["ana_polar"].is_monotonic_decreasing
-            ):
-                trim += 1
-                da = da.isel(ana_polar=slice(0, -1))
-            if trim:
-                analysis_warning(
-                    f"Non-monotonic angle values detected in ana_polar at end of travel. Trimmed {trim} data points.",
-                    "warning",
-                    "Removed non-monotonic data",
-                )
+            val = da["ana_polar"].values
+            steps = np.diff(val)
+            threshold = 0.1 * np.abs(np.median(steps))  # for motor noise
+            direction = np.sign(np.median(steps))
+            moving = np.flatnonzero(
+                (np.abs(steps) > threshold) & (np.sign(steps) == direction)
+            )
+            if moving.size:
+                last_good = int(moving[-1]) + 1
+                trim = val.size - last_good - 1
+                if trim:
+                    da = da.isel(ana_polar=slice(0, last_good + 1))
+                    analysis_warning(
+                        f"Non-monotonic angle values detected in ana_polar at end of travel. "
+                        f"Trimmed {trim} data point(s).",
+                        "warning",
+                        "Removed non-monotonic data",
+                    )
 
         # Load array into memory if lazy loading not required
         if not (lazy or (lazy is None and da.size > opts.FileIO.lazy_size)):

--- a/tutorials/7_nanoARPES.ipynb
+++ b/tutorials/7_nanoARPES.ipynb
@@ -99,7 +99,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "defocus_scan.plot_nanofocus(focus=\"defocus\")"
+    "defocus_scan.plot_nanofocus()"
    ]
   },
   {

--- a/tutorials/7_nanoARPES.ipynb
+++ b/tutorials/7_nanoARPES.ipynb
@@ -99,7 +99,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "defocus_scan.plot_nanofocus()"
+    "defocus_scan.plot_nanofocus(focus=\"defocus\")"
    ]
   },
   {


### PR DESCRIPTION
- `dim="defocus"` was used regardless of the focus parameter in `plot_nanofocus` - this has now been removed. It now tries to guess it first if it's not passed.
- removed repeated points at the end of travel in anapolar maps. The current `pandas.Index.is_monotonic_increasing` guard missed these because it allows equal neighbours.