### PR TITLE
Handle clipborad failures in disp panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Metadata reports `[nan, nan]` when a scan contains a few NaN readbacks ([PR#57](https://github.com/phrgab/peaks/pull/57))
 - Hard-coded `focus` dimension in `plot_nanofocus` ([PR#58](https://github.com/phrgab/peaks/pull/58))
 - Non-monotonic and repeated data at end of travel in i05 nano ana_polar maps ([PR#58](https://github.com/phrgab/peaks/pull/58))
+- Clicking _Copy_ in a `disp` panel raises `PyperclipException` on systems without a clipboard mechanism; text is now printed for manual copying instead ([PR#59](https://github.com/phrgab/peaks/pull/59))
 
 ### Changed
 

--- a/peaks/core/GUI/disp_panels/disp_2d.py
+++ b/peaks/core/GUI/disp_panels/disp_2d.py
@@ -920,7 +920,13 @@ class _Disp2D(QtWidgets.QMainWindow):
             k: f"{v:~D}" if isinstance(v, pint.Quantity) else v
             for k, v in norm_values.items()
         }
-        pyperclip.copy(f".metadata.set_normal_emission({norm_values_to_return})")
+        try:
+            pyperclip.copy(f".metadata.set_normal_emission({norm_values_to_return})")
+        except Exception as e:
+            print(
+                f"Could not access the system clipboard: {e}. "
+                f"Copy the following manually:\n.metadata.set_normal_emission({norm_values_to_return})"
+            )
 
     # ##############################
     # Signal connections

--- a/peaks/core/GUI/disp_panels/disp_3d.py
+++ b/peaks/core/GUI/disp_panels/disp_3d.py
@@ -926,7 +926,13 @@ class _Disp3D(QtWidgets.QMainWindow):
             k: f"{v:~D}" if isinstance(v, pint.Quantity) else v
             for k, v in norm_values.items()
         }
-        pyperclip.copy(f".metadata.set_normal_emission({norm_values_to_return})")
+        try:
+            pyperclip.copy(f".metadata.set_normal_emission({norm_values_to_return})")
+        except Exception as e:
+            print(
+                f"Could not access the system clipboard: {e}. "
+                f"Copy the following manually:\n.metadata.set_normal_emission({norm_values_to_return})"
+            )
 
     # ##############################
     # Signal connections

--- a/peaks/core/GUI/disp_panels/disp_4d.py
+++ b/peaks/core/GUI/disp_panels/disp_4d.py
@@ -419,6 +419,17 @@ class _Disp4D(QtWidgets.QMainWindow):
         # Set key press signals
         self.primary_dims_explorer_layout.keyPressed.connect(self._key_press_event)
 
+    def _copy_ROI_store(self):
+        """Copy the ROI store to the clipboard."""
+        text = f".attrs['ROI']={str(self.ROI_store)}"
+        try:
+            pyperclip.copy(text)
+        except Exception as e:
+            print(
+                f"Could not access the system clipboard: {e}. "
+                f"Copy the following manually:\n{text}"
+            )
+
         # Connect signals for ROI tab
         self.resetplots_button.clicked.connect(self._reset_roi_plots)
         self.setROI_button.clicked.connect(self._set_ROI_from_plot)
@@ -427,9 +438,7 @@ class _Disp4D(QtWidgets.QMainWindow):
         self.clear_ROI_store_button.clicked.connect(self._remove_all_ROIs_from_list)
         self.setROI_from_list_button.clicked.connect(self._set_ROI_from_list)
         self.roi_list_box.itemSelectionChanged.connect(self._select_ROI_from_list)
-        self.copy_ROI_store_button.clicked.connect(
-            lambda: pyperclip.copy(f".attrs['ROI']={str(self.ROI_store)}")
-        )
+        self.copy_ROI_store_button.clicked.connect(self._copy_ROI_store)
 
     # ##############################
     # Data handling

--- a/peaks/core/GUI/disp_panels/disp_4d.py
+++ b/peaks/core/GUI/disp_panels/disp_4d.py
@@ -419,6 +419,16 @@ class _Disp4D(QtWidgets.QMainWindow):
         # Set key press signals
         self.primary_dims_explorer_layout.keyPressed.connect(self._key_press_event)
 
+        # Connect signals for ROI tab
+        self.resetplots_button.clicked.connect(self._reset_roi_plots)
+        self.setROI_button.clicked.connect(self._set_ROI_from_plot)
+        self.addROI_button.clicked.connect(self._add_ROI_to_list)
+        self.removeROI_button.clicked.connect(self._remove_selected_ROI_from_list)
+        self.clear_ROI_store_button.clicked.connect(self._remove_all_ROIs_from_list)
+        self.setROI_from_list_button.clicked.connect(self._set_ROI_from_list)
+        self.roi_list_box.itemSelectionChanged.connect(self._select_ROI_from_list)
+        self.copy_ROI_store_button.clicked.connect(self._copy_ROI_store)
+
     def _copy_ROI_store(self):
         """Copy the ROI store to the clipboard."""
         text = f".attrs['ROI']={str(self.ROI_store)}"
@@ -429,16 +439,6 @@ class _Disp4D(QtWidgets.QMainWindow):
                 f"Could not access the system clipboard: {e}. "
                 f"Copy the following manually:\n{text}"
             )
-
-        # Connect signals for ROI tab
-        self.resetplots_button.clicked.connect(self._reset_roi_plots)
-        self.setROI_button.clicked.connect(self._set_ROI_from_plot)
-        self.addROI_button.clicked.connect(self._add_ROI_to_list)
-        self.removeROI_button.clicked.connect(self._remove_selected_ROI_from_list)
-        self.clear_ROI_store_button.clicked.connect(self._remove_all_ROIs_from_list)
-        self.setROI_from_list_button.clicked.connect(self._set_ROI_from_list)
-        self.roi_list_box.itemSelectionChanged.connect(self._select_ROI_from_list)
-        self.copy_ROI_store_button.clicked.connect(self._copy_ROI_store)
 
     # ##############################
     # Data handling


### PR DESCRIPTION
Fall back to plain prints if `pyperclip` can't access the system clipboard