### PR TITLE
Correcting scan name display for a leaf of a dt in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hard-coded `focus` dimension in `plot_nanofocus` ([PR#58](https://github.com/phrgab/peaks/pull/58))
 - Non-monotonic and repeated data at end of travel in i05 nano ana_polar maps ([PR#58](https://github.com/phrgab/peaks/pull/58))
 - Clicking _Copy_ in a `disp` panel raises `PyperclipException` on systems without a clipboard mechanism; text is now printed for manual copying instead ([PR#59](https://github.com/phrgab/peaks/pull/59))
+- Minor doc fixes ([PR#61](https://github.com/phrgab/peaks/pull/61))
 
 ### Changed
 

--- a/tutorials/1_getting_started.ipynb
+++ b/tutorials/1_getting_started.ipynb
@@ -638,7 +638,7 @@
     ":::{attention}\n",
     "Note, the {py:class}`xarray.DataTree` structure requires data in the leaves of the tree to be in a {py:class}`xarray.Dataset` format, rather than a {py:class}`xarray.DataArray`. Unless the data is already in {py:class}`xarray.Dataset` form, `peaks` convention is to convert the {py:class}`xarray.DataArray` to a {py:class}`xarray.Dataset` with a single data variable `data`. Note the additional {py:attr}`.data <xarray.DataArray.data>` used above the access the underlying {py:class}`xarray.DataArray`. This {py:class}`xarray.DataArray` now has the name `data` rather than the default scan name. The original scan (file) name is still accessible via the [metadata](#metadata)\n",
     "```python\n",
-    "multiple_disp.disp.scan.name\n",
+    "multiple_disp.disp1.data.metadata.scan.name\n",
     "```\n",
     ":::"
    ]


### PR DESCRIPTION
Fix #60 