### PR TITLE
Add missing units to i05 deflector metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Inverted lazy-loading threshold and missing dask chunking in `NetCDFLoader` ([PR#66](https://github.com/phrgab/peaks/pull/66))
 - Intermittent bug where interactive fit plots (`plot_fit`) would fail to render in the built docs ([PR#67](https://github.com/phrgab/peaks/pull/67))
 - Cap embedded slider states in docs builds ([PR#67](https://github.com/phrgab/peaks/pull/67))
+- Missing units on the deflector metadata for I05 data ([PR#70](https://github.com/phrgab/peaks/pull/70))
 
 ### Changed
 

--- a/peaks/core/fileIO/loaders/diamond.py
+++ b/peaks/core/fileIO/loaders/diamond.py
@@ -315,6 +315,10 @@ class I05ARPESLoader(DiamondNXSLoader, BaseARPESDataLoader):
 
     _hdf5_metadata_fixed_units = {
         "entry1/sample/heater_percent": "%",
+        "entry1/instrument/analyser/deflector_x": "deg",
+        "entry1/instrument/deflector_x/deflector_x": "deg",
+        "entry1/instrument/analyser/detector_y": "deg",
+        "entry1/instrument/analyser/deflector_y": "deg",
     }
 
     _data_group_key_resolution_order = ["analyser"]
@@ -872,4 +876,10 @@ class I05NanoNewARPESLoader(I05NanoARPESLoader):
         "analyser_model": "FIXED_VALUE:MBS A1",
         "analyser_deflector_parallel": "entry1/instrument/analyser/deflector_y",
         "analyser_deflector_perp": "entry1/instrument/analyser/deflector_x",
+    }
+
+    _hdf5_metadata_fixed_units = {
+        **I05NanoARPESLoader._hdf5_metadata_fixed_units,
+        "entry1/instrument/analyser/deflector_x": "deg",
+        "entry1/instrument/analyser/deflector_y": "deg",
     }


### PR DESCRIPTION
Raw datasets don't record units for analyser deflectors so they end up unitless in `peaks`-parsed metadata. Consequently, the downstream stack for getting normal-emission reference and doing k-conversion won't work properly because `_get_angles_Ishida_Shin` drops these bare floats via its `isinstance(value, pint.Quantity)` check.