### PR TITLE
Improve local mirror handling for sample data and CIF download reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Limit font size and max lines of titles in `plot_fit` outputs ([PR#56](https://github.com/phrgab/peaks/pull/56))
+- Improve local mirror (for sample data) handling and add COD fallback URLs for `ExampleData.structure()` ([PR#72](https://github.com/phrgab/peaks/pull/72))
 
 ### Removed
 

--- a/peaks/core/utils/sample_data.py
+++ b/peaks/core/utils/sample_data.py
@@ -30,31 +30,60 @@ class ZenodoDownloader:
     with Zenodo serving as the fallback (used in CI).
     """
 
+    _mirro_warned = False
+
     def __init__(self, file_list, token=None):
         self.root_url = ROOT_URL.rstrip("/")
         self.file_list = file_list
         self.token = token or os.getenv("ZENODO_TOKEN")
-        self.local_mirror = os.getenv("LOCAL_MIRROR_PATH")
+        self.local_mirror = os.getenv("LOCAL_MIRROR_PATH") or ""
         self._in_ci = bool(os.getenv("CI"))
-        self._ci_log()
+        self._mirror_valid = bool(self.local_mirror) and os.path.isdir(self.local_mirror)
         self._tempdir_context = None
         self.downloaded_files = {}
 
-    # def _ci_log(self, message):
-    def _ci_log(self):
-        """Log plain messages in CI environment."""
-        # if self._in_ci:
-        print(
-            f"[DEBUG] CI env var is {os.getenv('CI')!r}, self._in_ci = {self._in_ci}",
-            flush=True,
-        )
+        if self.local_mirror and not self._mirror_valid:
+            self._warn_invalid_mirror()
+
+    def _warn_invalid_mirror(self):
+        if self._in_ci:  # in CI env
+            print(
+                f"[PEAKS WARNING] LOCAL_MIRROR_PATH={self.local_mirror!r} is not a valid directory. Falling back to Zenodo download.",
+                flush=True,
+            )
+        elif not ZenodoDownloader._mirro_warned:  # for users
+            analysis_warning(
+                f"<code>LOCAL_MIRROR_PATH</code> is set to <code>{self.local_mirror}</code>, "
+                f"but this is not a valid directory. Sample data will be downloaded from Zenodo instead.",
+                title="Invalid LOCAL_MIRROR_PATH",
+                warn_type="warning",
+            )
+            ZenodoDownloader._mirro_warned = True
+
+    def _ci_log(self, message):
+        """Log line, printed only in CI environment."""
+        if self._in_ci:
+            print(
+                f"[PEAKS INFO] {message}",
+                flush=True,
+            )
 
     def _get_local_path(self, filename):
         """Check if local mirror available and if files exist there."""
-        if self.local_mirror and os.path.isdir(self.local_mirror):
+        if self._mirror_valid:
             path = os.path.join(self.local_mirror, filename)
             if os.path.isfile(path):
+                self._ci_log(f"found in mirror    | {filename}")
                 return path
+            self._ci_log(f"not in mirror      | {filename} -> Zenodo")
+            if not self._in_ci:  # User sets LOCAL_MIRROR_PATH but file not found
+                analysis_warning(
+                    f"File <code>{filename}</code> was not found in local mirror at<code>{self.local_mirror}</code>. "
+                    "Downloading from Zenodo instead.",
+                    title="Local mirror miss",
+                    warn_type="info",
+                )
+        self._ci_log(f"no mirror set      | {filename} -> Zenodo")
         return None
 
     def _make_headers_if_needed(self, url):

--- a/peaks/core/utils/sample_data.py
+++ b/peaks/core/utils/sample_data.py
@@ -19,6 +19,12 @@ from peaks.core.utils.misc import analysis_warning
 
 ROOT_URL = "https://zenodo.org/api/records/19336694/files"
 
+COD_URLS = (
+    "https://www.crystallography.net/cod/4515175.cif",
+    "https://qiserver.ugr.es/cod/4515175.cif",
+    "http://cod.ibt.lt/cod/4515175.cif",
+)
+
 
 class ZenodoDownloader:
     """Helper class to download files from Zenodo.
@@ -78,7 +84,7 @@ class ZenodoDownloader:
             self._ci_log(f"not in mirror      | {filename} -> Zenodo")
             if not self._in_ci:  # User sets LOCAL_MIRROR_PATH but file not found
                 analysis_warning(
-                    f"File <code>{filename}</code> was not found in local mirror at<code>{self.local_mirror}</code>. "
+                    f"File <code>{filename}</code> was not found in local mirror at <code>{self.local_mirror}</code>. "
                     "Downloading from Zenodo instead.",
                     title="Local mirror miss",
                     warn_type="info",
@@ -165,9 +171,6 @@ class ZenodoDownloader:
                 dest_path = os.path.join(tmpdir, filename)
                 if local_path:
                     shutil.copy(local_path, dest_path)
-                    print(
-                        f"[DEBUG] Copied {filename} from local mirror to temporary directory."
-                    )
                 else:
                     url = f"{self.root_url}/{filename}/content"
                     self._download_with_progress(url, dest_path)
@@ -402,13 +405,15 @@ class ExampleData:
                 local_path = os.path.join(local_mirror, "4515175.cif")
                 if os.path.exists(local_path):
                     data = load(local_path)
-                    print(
-                        f"[DEBUG] Loaded structure from local mirror: {local_path} data type is {type(data)}"
-                    )
             if data is None:
-                url = "https://qiserver.ugr.es/cod/4515175.cif"
-                response = requests.get(url)
-                if response.status_code == 200:
+                error = []
+                for url in COD_URLS:
+                    try:
+                        response = requests.get(url, timeout=(30, 300))
+                        response.raise_for_status()
+                    except requests.exceptions.RequestException as e:
+                        error.append(f"Failed to download from {url}: {e}")
+                        continue
                     tmp = tempfile.NamedTemporaryFile("w+", suffix=".cif", delete=False)
                     try:
                         tmp.write(response.text)
@@ -416,9 +421,11 @@ class ExampleData:
                         data = load(tmp.name)
                     finally:
                         os.unlink(tmp.name)
+                    break
                 else:
                     raise ValueError(
-                        f"Failed to download CIF. HTTP status code: {response.status_code}"
+                        "Failed to download CIF from any known mirror:\n  "
+                        + "\n".join(error)
                     )
             cls._cache["structure"] = data
         return deepcopy(data)

--- a/peaks/core/utils/sample_data.py
+++ b/peaks/core/utils/sample_data.py
@@ -35,6 +35,13 @@ class ZenodoDownloader:
         self.file_list = file_list
         self.token = token or os.getenv("ZENODO_TOKEN")
         self.local_mirror = os.getenv("LOCAL_MIRROR_PATH")
+        if self.local_mirror and not os.path.isdir(self.local_mirror):
+            analysis_warning(
+                f"LOCAL_MIRROR_PATH is set to <code>{self.local_mirror}</code>, but this directory does not exist. "
+                "Files will be downloaded from Zenodo instead.",
+                title="Invalid LOCAL_MIRROR_PATH",
+                warn_type="warning",
+            )
         self._tempdir_context = None
         self.downloaded_files = {}
 

--- a/peaks/core/utils/sample_data.py
+++ b/peaks/core/utils/sample_data.py
@@ -437,7 +437,7 @@ class ExampleData:
                     break
                 else:
                     raise ValueError(
-                        "Failed to download CIF from any known mirror:\n  "
+                        "Failed to download CIF from any known mirrors:\n  "
                         + "\n  ".join(errors)
                     )
             cls._cache["structure"] = data

--- a/peaks/core/utils/sample_data.py
+++ b/peaks/core/utils/sample_data.py
@@ -125,6 +125,9 @@ class ZenodoDownloader:
                 dest_path = os.path.join(tmpdir, filename)
                 if local_path:
                     shutil.copy(local_path, dest_path)
+                    print(
+                        f"[DEBUG] Copied {filename} from local mirror to temporary directory."
+                    )
                 else:
                     url = f"{self.root_url}/{filename}/content"
                     self._download_with_progress(url, dest_path)
@@ -359,6 +362,9 @@ class ExampleData:
                 local_path = os.path.join(local_mirror, "4515175.cif")
                 if os.path.exists(local_path):
                     data = load(local_path)
+                    print(
+                        f"[DEBUG] Loaded structure from local mirror: {local_path} data type is {type(data)}"
+                    )
             if data is None:
                 url = "https://qiserver.ugr.es/cod/4515175.cif"
                 response = requests.get(url)

--- a/peaks/core/utils/sample_data.py
+++ b/peaks/core/utils/sample_data.py
@@ -36,6 +36,7 @@ class ZenodoDownloader:
         self.token = token or os.getenv("ZENODO_TOKEN")
         self.local_mirror = os.getenv("LOCAL_MIRROR_PATH")
         self._in_ci = bool(os.getenv("CI"))
+        self._ci_log()
         self._tempdir_context = None
         self.downloaded_files = {}
 

--- a/peaks/core/utils/sample_data.py
+++ b/peaks/core/utils/sample_data.py
@@ -36,7 +36,7 @@ class ZenodoDownloader:
     with Zenodo serving as the fallback (used in CI).
     """
 
-    _mirro_warned = False
+    _mirror_warned = False
 
     def __init__(self, file_list, token=None):
         self.root_url = ROOT_URL.rstrip("/")
@@ -57,14 +57,14 @@ class ZenodoDownloader:
                 f"[PEAKS WARNING] LOCAL_MIRROR_PATH={self.local_mirror!r} is not a valid directory. Falling back to Zenodo download.",
                 flush=True,
             )
-        elif not ZenodoDownloader._mirro_warned:  # for users
+        elif not ZenodoDownloader._mirror_warned:  # for users
             analysis_warning(
                 f"<code>LOCAL_MIRROR_PATH</code> is set to <code>{self.local_mirror}</code>, "
                 f"but this is not a valid directory. Sample data will be downloaded from Zenodo instead.",
                 title="Invalid LOCAL_MIRROR_PATH",
                 warn_type="warning",
             )
-            ZenodoDownloader._mirro_warned = True
+            ZenodoDownloader._mirror_warned = True
 
     def _ci_log(self, message):
         """Log line, printed only in CI environment."""
@@ -89,6 +89,7 @@ class ZenodoDownloader:
                     title="Local mirror miss",
                     warn_type="info",
                 )
+            return None
         self._ci_log(f"no mirror set      | {filename} -> Zenodo")
         return None
 
@@ -397,7 +398,7 @@ class ExampleData:
     @classmethod
     def structure(cls):
         """If `LOCAL_MIRROR_PATH` is set, files will be copied from this local directory
-        with the database sever as the fallback (used in CI)."""
+        with the database server as the fallback (used in CI)."""
         data = cls._cache.get("structure")
         if data is None:
             local_mirror = os.getenv("LOCAL_MIRROR_PATH")
@@ -405,14 +406,26 @@ class ExampleData:
                 local_path = os.path.join(local_mirror, "4515175.cif")
                 if os.path.exists(local_path):
                     data = load(local_path)
+                    if os.getenv("CI"):
+                        print(
+                            "[PEAKS INFO] found in mirror    | 4515175.cif", flush=True
+                        )
             if data is None:
-                error = []
+                if os.getenv("CI"):
+                    msg = (
+                        "not in mirror      " if local_mirror else "no mirror set      "
+                    )
+                    print(
+                        f"[PEAKS INFO] {msg} | 4515175.cif -> COD",
+                        flush=True,
+                    )
+                errors = []
                 for url in COD_URLS:
                     try:
-                        response = requests.get(url, timeout=(30, 300))
+                        response = requests.get(url, timeout=(30, 60))
                         response.raise_for_status()
                     except requests.exceptions.RequestException as e:
-                        error.append(f"Failed to download from {url}: {e}")
+                        errors.append(f"Failed to download from {url}: {e}")
                         continue
                     tmp = tempfile.NamedTemporaryFile("w+", suffix=".cif", delete=False)
                     try:
@@ -425,7 +438,7 @@ class ExampleData:
                 else:
                     raise ValueError(
                         "Failed to download CIF from any known mirror:\n  "
-                        + "\n".join(error)
+                        + "\n  ".join(errors)
                     )
             cls._cache["structure"] = data
         return deepcopy(data)

--- a/peaks/core/utils/sample_data.py
+++ b/peaks/core/utils/sample_data.py
@@ -35,15 +35,18 @@ class ZenodoDownloader:
         self.file_list = file_list
         self.token = token or os.getenv("ZENODO_TOKEN")
         self.local_mirror = os.getenv("LOCAL_MIRROR_PATH")
-        if self.local_mirror and not os.path.isdir(self.local_mirror):
-            analysis_warning(
-                f"LOCAL_MIRROR_PATH is set to <code>{self.local_mirror}</code>, but this directory does not exist. "
-                "Files will be downloaded from Zenodo instead.",
-                title="Invalid LOCAL_MIRROR_PATH",
-                warn_type="warning",
-            )
+        self._in_ci = bool(os.getenv("CI"))
         self._tempdir_context = None
         self.downloaded_files = {}
+
+    # def _ci_log(self, message):
+    def _ci_log(self):
+        """Log plain messages in CI environment."""
+        # if self._in_ci:
+        print(
+            f"[DEBUG] CI env var is {os.getenv('CI')!r}, self._in_ci = {self._in_ci}",
+            flush=True,
+        )
 
     def _get_local_path(self, filename):
         """Check if local mirror available and if files exist there."""


### PR DESCRIPTION
- Adding CI-only logging for mirror hit/miss/not-set per file so it's clear in ci logs whether sample data came from the local mirror or fell back to zenodo/COD
- Warn users when `LOCAL_MIRROR_PATH` is set but invalid, or when a specific file is missing from an otherwise valid one
- CIF file. Replace the single cod URL with a fallback list containing the main site and two mirrors, tried in order until one succeeds